### PR TITLE
Add gradle dependency to README

### DIFF
--- a/README
+++ b/README
@@ -13,6 +13,12 @@ This library collects various accessibility-related checks on View objects as
 well as AccessibilityNodeInfo objects (which the Android framework derives from
 Views and sends to AccessibilityServices).
 
+Including the Library in your project
+-------------------------------------
+Gradle users can include the following dependency (available on JCenter):
+
+androidTestCompile 'com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:2.0'
+
 Building the Library
 --------------------
 Use maven to build the library. You will need to install Android 5.0 (API 21) 

--- a/README
+++ b/README
@@ -17,7 +17,7 @@ Including the Library in your project
 -------------------------------------
 Gradle users can include the following dependency (available on JCenter):
 
-androidTestCompile 'com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:2.0'
+androidTestCompile 'com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:2.1'
 
 Building the Library
 --------------------


### PR DESCRIPTION
It wasn't clear that the framework was published - adding an instruction to allow users to import this dependency into their Gradle projects will remove obstacles for adoption.
