### PR TITLE
WIP: Produce java7 bytecode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .gradle
+.idea
+build
+local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.11'
         classpath 'digital.wup:android-maven-publish:3.6.3'
     }
@@ -31,8 +31,8 @@ android {
         abortOnError false
     }
     compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
+        targetCompatibility 1.7
+        sourceCompatibility 1.7
     }
 }
 
@@ -127,7 +127,8 @@ dependencies {
     implementation 'androidx.core:core:1.0.0'
     implementation 'com.google.android.material:material:1.2.0-rc01'
     implementation 'com.google.guava:guava:28.2-android'
-    implementation 'org.checkerframework:checker:3.1.1'
+    implementation 'org.checkerframework:checker-compat-qual:2.5.5'
+    implementation 'org.checkerframework:dataflow:2.5.5'
     implementation 'org.hamcrest:hamcrest-library:2.2'
     implementation 'org.hamcrest:hamcrest-core:2.2'
     implementation 'org.jsoup:jsoup:1.12.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,14 @@
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Wed Jan 06 18:43:25 PST 2021
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jan 06 18:42:35 PST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckPreset.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckPreset.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Pre-sets for check configurations used with {@code getConfigForPreset}
@@ -83,7 +83,7 @@ public enum AccessibilityCheckPreset {
       CLASS_NAME_TO_HIERARCHY_CHECK = mapClassNameToInstance(CLASS_TO_HIERARCHY_CHECK);
 
   /** @return an instance of a {@link AccessibilityHierarchyCheck} of the given class type. */
-  public static @Nullable AccessibilityHierarchyCheck getHierarchyCheckForClass(
+  public static @NullableDecl AccessibilityHierarchyCheck getHierarchyCheckForClass(
       Class<? extends AccessibilityHierarchyCheck> clazz) {
     return CLASS_TO_HIERARCHY_CHECK.get(clazz);
   }
@@ -92,7 +92,7 @@ public enum AccessibilityCheckPreset {
    * @return an instance of the class with the given name if it extends from {@link
    *     AccessibilityHierarchyCheck}.
    */
-  public static @Nullable AccessibilityHierarchyCheck getHierarchyCheckForClassName(
+  public static @NullableDecl AccessibilityHierarchyCheck getHierarchyCheckForClassName(
       String className) {
     return CLASS_NAME_TO_HIERARCHY_CHECK.get(className);
   }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckPresetAndroid.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckPresetAndroid.java
@@ -25,7 +25,7 @@ import com.google.android.apps.common.testing.accessibility.framework.checks.Tra
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Provides deprecated methods for {@link AccessibilityCheckPreset}. */
 @SuppressWarnings("deprecation") // Need to support AccessibilityViewHierarchyCheck..
@@ -164,7 +164,7 @@ public final class AccessibilityCheckPresetAndroid {
 
     @Override
     public List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(
-        View root, @Nullable Parameters parameters) {
+        View root, @NullableDecl Parameters parameters) {
       // We lie about the name of the fromCheck so that this class is not known externally.
       return super.runDelegationCheckOnView(root, toCheck, toCheck, parameters);
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckResult.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckResult.java
@@ -22,7 +22,7 @@ import com.google.android.apps.common.testing.accessibility.framework.proto.Acce
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * The result of an accessibility check. The results are "interesting" in the sense that they
@@ -103,7 +103,7 @@ public abstract class AccessibilityCheckResult {
 
   private final Class<? extends AccessibilityCheck> checkClass;
   private final AccessibilityCheckResultType type;
-  private final @Nullable CharSequence message;
+  private final @NullableDecl CharSequence message;
 
   /**
    * @param checkClass The class of the check that generated the error
@@ -114,7 +114,7 @@ public abstract class AccessibilityCheckResult {
   public AccessibilityCheckResult(
       Class<? extends AccessibilityCheck> checkClass,
       AccessibilityCheckResultType type,
-      @Nullable CharSequence message) {
+      @NullableDecl CharSequence message) {
     this.checkClass = checkClass;
     this.type = type;
     this.message = message;
@@ -198,7 +198,7 @@ public abstract class AccessibilityCheckResult {
      * @param view the {@link View} to describe
      * @return a String description of the given {@link View}
      */
-    public String describeView(@Nullable View view) {
+    public String describeView(@NullableDecl View view) {
       StringBuilder message = new StringBuilder();
       if ((view != null
           && view.getId() != View.NO_ID

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckResultBaseUtils.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckResultBaseUtils.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableBiMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -64,7 +64,7 @@ public final class AccessibilityCheckResultBaseUtils {
   static <T extends AccessibilityCheckResult> List<T> getResultsForCheck(
       Iterable<T> results,
       Class<? extends AccessibilityCheck> checkClass,
-      @Nullable ImmutableBiMap<?, ?> aliases) {
+      @NullableDecl ImmutableBiMap<?, ?> aliases) {
     List<T> resultsForCheck = new ArrayList<T>();
     for (T result : results) {
       Class<? extends AccessibilityCheck> resultCheckClass = result.getSourceCheckClass();
@@ -164,7 +164,7 @@ public final class AccessibilityCheckResultBaseUtils {
    * @return a {@code Matcher} for a {@code AccessibilityCheckResult}
    */
   static Matcher<AccessibilityCheckResult> matchesChecks(
-      final Matcher<?> classMatcher, final @Nullable ImmutableBiMap<?, ?> aliases) {
+      final Matcher<?> classMatcher, final @NullableDecl ImmutableBiMap<?, ?> aliases) {
     return new TypeSafeMemberMatcher<AccessibilityCheckResult>("source check", classMatcher) {
       @Override
       public boolean matchesSafely(AccessibilityCheckResult result) {
@@ -200,7 +200,7 @@ public final class AccessibilityCheckResultBaseUtils {
    */
   static Matcher<AccessibilityCheckResult> matchesCheckNames(
       final Matcher<? super String> classNameMatcher,
-      final @Nullable ImmutableBiMap<?, ?> aliases) {
+      final @NullableDecl ImmutableBiMap<?, ?> aliases) {
     return new TypeSafeMemberMatcher<AccessibilityCheckResult>(
         "source check name", classNameMatcher) {
       @Override
@@ -223,7 +223,7 @@ public final class AccessibilityCheckResultBaseUtils {
    * class can match a result with an old check class. Or a Matcher that specifies an old check
    * class can match a result with a new check class.
    */
-  private static @Nullable Object getAlias(Object obj, @Nullable ImmutableBiMap<?, ?> aliases) {
+  private static @NullableDecl Object getAlias(Object obj, @NullableDecl ImmutableBiMap<?, ?> aliases) {
     if (aliases == null) {
       return null;
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckResultDescriptor.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckResultDescriptor.java
@@ -19,7 +19,7 @@ import com.google.android.apps.common.testing.accessibility.framework.replacemen
 import com.google.android.apps.common.testing.accessibility.framework.replacements.TextUtils;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.ViewHierarchyElement;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * An object that describes an {@link AccessibilityCheckResult}. This can be extended to provide
@@ -61,7 +61,7 @@ public class AccessibilityCheckResultDescriptor {
    * @param view the {@link View} to describe
    * @return a String description of the given {@link View}
    */
-  public String describeView(@Nullable View view) {
+  public String describeView(@NullableDecl View view) {
     StringBuilder message = new StringBuilder();
     if ((view != null
         && view.getId() != View.NO_ID
@@ -88,7 +88,7 @@ public class AccessibilityCheckResultDescriptor {
    * @param element the {@link ViewHierarchyElement} to describe
    * @return a String description of the given {@link ViewHierarchyElement}
    */
-  public String describeElement(@Nullable ViewHierarchyElement element) {
+  public String describeElement(@NullableDecl ViewHierarchyElement element) {
     if (element == null) {
       return "<null>";
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityHierarchyCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityHierarchyCheck.java
@@ -20,7 +20,7 @@ import com.google.android.apps.common.testing.accessibility.framework.uielement.
 import com.google.common.annotations.Beta;
 import java.util.List;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Base class to check the accessibility of {@code ViewHierarchyElement}s.
@@ -35,14 +35,14 @@ public abstract class AccessibilityHierarchyCheck extends AccessibilityCheck {
    * Returns the identifier of a Google Accessibility Help article related to the issues identified
    * by this check, or {@code null} if there is not yet an article on these issues.
    */
-  protected abstract @Nullable String getHelpTopic();
+  protected abstract @NullableDecl String getHelpTopic();
 
   /**
    * Returns the string representation of a URL for a Google Accessibility Help article related to
    * the issues identified by this check, or {@code null} if there is not yet an article on these
    * issues.
    */
-  public @Nullable String getHelpUrl() {
+  public @NullableDecl String getHelpUrl() {
     String topic = getHelpTopic();
     return (topic == null) ? null : String.format(ANDROID_A11Y_HELP_URL, getHelpTopic());
   }
@@ -55,7 +55,7 @@ public abstract class AccessibilityHierarchyCheck extends AccessibilityCheck {
    * no QuestionHandler has been declared for this check
    */
   @Beta
-  public @Nullable QuestionHandler getQuestionHandler() {
+  public @NullableDecl QuestionHandler getQuestionHandler() {
     return null;
   }
 
@@ -98,7 +98,7 @@ public abstract class AccessibilityHierarchyCheck extends AccessibilityCheck {
    * @return a localized message for the result data
    */
   public abstract String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata);
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata);
 
   /**
    * Generates a concise human-readable message describing a given result, supporting standard HTML
@@ -132,7 +132,7 @@ public abstract class AccessibilityHierarchyCheck extends AccessibilityCheck {
    * @return a localized {@link CharSequence} of the abbreviated message for the result datq
    */
   public abstract String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata);
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata);
 
   /**
    * Run the check on a hierarchy of ViewHierarchyElements. Because these elements support partial
@@ -158,8 +158,8 @@ public abstract class AccessibilityHierarchyCheck extends AccessibilityCheck {
    */
   public abstract List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters);
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters);
 
   /**
    * @see AccessibilityHierarchyCheck#runCheckOnHierarchy(AccessibilityHierarchy,
@@ -175,7 +175,7 @@ public abstract class AccessibilityHierarchyCheck extends AccessibilityCheck {
    *      ViewHierarchyElement, Metadata)
    */
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
-      AccessibilityHierarchy hierarchy, @Nullable ViewHierarchyElement fromRoot) {
+      AccessibilityHierarchy hierarchy, @NullableDecl ViewHierarchyElement fromRoot) {
     return runCheckOnHierarchy(hierarchy, fromRoot, null);
   }
 
@@ -185,7 +185,7 @@ public abstract class AccessibilityHierarchyCheck extends AccessibilityCheck {
    * AccessibilityCheckResult.AccessibilityCheckResultType}. Larger values have a greater
    * importance.
    */
-  public @Nullable Double getSecondaryPriority(AccessibilityHierarchyCheckResult result) {
+  public @NullableDecl Double getSecondaryPriority(AccessibilityHierarchyCheckResult result) {
     return null;
   }
 
@@ -203,7 +203,7 @@ public abstract class AccessibilityHierarchyCheck extends AccessibilityCheck {
    *     depth-first ordering
    */
   protected static List<? extends ViewHierarchyElement> getElementsToEvaluate(
-      @Nullable ViewHierarchyElement fromRoot, AccessibilityHierarchy hierarchy) {
+      @NullableDecl ViewHierarchyElement fromRoot, AccessibilityHierarchy hierarchy) {
     return (fromRoot != null) ? fromRoot.getSelfAndAllDescendants()
         : hierarchy.getActiveWindow().getAllViews();
   }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityHierarchyCheckResult.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityHierarchyCheckResult.java
@@ -10,7 +10,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Objects;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.checkerframework.dataflow.qual.Pure;
 import org.jsoup.Jsoup;
 
@@ -20,8 +20,8 @@ import org.jsoup.Jsoup;
 public class AccessibilityHierarchyCheckResult extends AccessibilityCheckResult {
 
   private final int resultId;
-  private final @Nullable ViewHierarchyElement element;
-  private final @Nullable ResultMetadata metadata;
+  private final @NullableDecl ViewHierarchyElement element;
+  private final @NullableDecl ResultMetadata metadata;
   private final ImmutableList<Answer> answers;
 
   /**
@@ -38,9 +38,9 @@ public class AccessibilityHierarchyCheckResult extends AccessibilityCheckResult 
   public AccessibilityHierarchyCheckResult(
       Class<? extends AccessibilityHierarchyCheck> checkClass,
       AccessibilityCheckResultType type,
-      @Nullable ViewHierarchyElement element,
+      @NullableDecl ViewHierarchyElement element,
       int resultId,
-      @Nullable ResultMetadata metadata,
+      @NullableDecl ResultMetadata metadata,
       ImmutableList<Answer> answers) {
     super(checkNotNull(checkClass), checkNotNull(type), null);
     this.element = element;
@@ -59,10 +59,10 @@ public class AccessibilityHierarchyCheckResult extends AccessibilityCheckResult 
   public AccessibilityHierarchyCheckResult(
       Class<? extends AccessibilityHierarchyCheck> checkClass,
       AccessibilityCheckResultType type,
-      @Nullable ViewHierarchyElement element,
+      @NullableDecl ViewHierarchyElement element,
       int resultId,
-      @Nullable ResultMetadata metadata) {
-    this(checkClass, type, element, resultId, metadata, ImmutableList.of());
+      @NullableDecl ResultMetadata metadata) {
+    this(checkClass, type, element, resultId, metadata, ImmutableList.<Answer>of());
   }
 
   /**
@@ -194,7 +194,7 @@ public class AccessibilityHierarchyCheckResult extends AccessibilityCheckResult 
    * @return a metadata for this result, or {@code null} if none was provided
    */
   @Pure
-  public @Nullable ResultMetadata getMetadata() {
+  public @NullableDecl ResultMetadata getMetadata() {
     return metadata;
   }
 
@@ -205,7 +205,7 @@ public class AccessibilityHierarchyCheckResult extends AccessibilityCheckResult 
    *     to a specific element within a view hierarchy.
    */
   @Pure
-  public @Nullable ViewHierarchyElement getElement() {
+  public @NullableDecl ViewHierarchyElement getElement() {
     return element;
   }
 
@@ -214,7 +214,7 @@ public class AccessibilityHierarchyCheckResult extends AccessibilityCheckResult 
    *
    * @see AccessibilityHierarchyCheck#getSecondaryPriority
    */
-  public @Nullable Double getSecondaryPriority() {
+  public @NullableDecl Double getSecondaryPriority() {
     return getCheck().getSecondaryPriority(this);
   }
 
@@ -242,7 +242,7 @@ public class AccessibilityHierarchyCheckResult extends AccessibilityCheckResult 
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(@NullableDecl Object o) {
     if (this == o) {
       return true;
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityViewCheckResult.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityViewCheckResult.java
@@ -20,7 +20,7 @@ import android.view.View;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.AccessibilityHierarchy;
 import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.Image;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.checkerframework.dataflow.qual.Pure;
 
 /**
@@ -34,9 +34,9 @@ import org.checkerframework.dataflow.qual.Pure;
 @Deprecated
 public class AccessibilityViewCheckResult extends AccessibilityCheckResult {
 
-  private final @Nullable View view;
-  private final @Nullable Image viewImage;
-  private final @Nullable AccessibilityHierarchyCheckResult hierarchyCheckResult;
+  private final @NullableDecl View view;
+  private final @NullableDecl Image viewImage;
+  private final @NullableDecl AccessibilityHierarchyCheckResult hierarchyCheckResult;
 
   /**
    * @param checkClass The check that generated the error
@@ -52,8 +52,8 @@ public class AccessibilityViewCheckResult extends AccessibilityCheckResult {
       Class<? extends AccessibilityCheck> checkClass,
       AccessibilityCheckResultType type,
       CharSequence message,
-      @Nullable View view,
-      @Nullable Image viewImage) {
+      @NullableDecl View view,
+      @NullableDecl Image viewImage) {
     super(checkClass, type, message);
     this.view = view;
     this.viewImage = viewImage;
@@ -65,7 +65,7 @@ public class AccessibilityViewCheckResult extends AccessibilityCheckResult {
       Class<? extends AccessibilityCheck> checkClass,
       AccessibilityCheckResultType type,
       CharSequence message,
-      @Nullable View view) {
+      @NullableDecl View view) {
     this(checkClass, type, message, view, /* viewImage= */ null);
   }
 
@@ -77,7 +77,7 @@ public class AccessibilityViewCheckResult extends AccessibilityCheckResult {
   /* package */ AccessibilityViewCheckResult(
       Class<? extends AccessibilityCheck> checkClass,
       AccessibilityHierarchyCheckResult hierarchyCheckResult,
-      @Nullable View view) {
+      @NullableDecl View view) {
     super(checkClass, hierarchyCheckResult.getType(), /* message= */ null);
     this.view = view;
     viewImage =
@@ -107,12 +107,12 @@ public class AccessibilityViewCheckResult extends AccessibilityCheckResult {
    * Returns the view to which the result applies, or {@code null} if the result does not apply to a
    * specific {@code View}.
    */
-  public @Nullable View getView() {
+  public @NullableDecl View getView() {
     return view;
   }
 
   /** Returns an image of the view to which the result applies, in some cases, or {@code null}. */
-  public @Nullable Image getViewImage() {
+  public @NullableDecl Image getViewImage() {
     return viewImage;
   }
 
@@ -147,7 +147,7 @@ public class AccessibilityViewCheckResult extends AccessibilityCheckResult {
    *     AccessibilityHierarchyCheckResult
    */
   @Pure
-  public @Nullable ResultMetadata getMetadata() {
+  public @NullableDecl ResultMetadata getMetadata() {
     return checkNotNull(hierarchyCheckResult).getMetadata();
   }
 

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityViewHierarchyCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/AccessibilityViewHierarchyCheck.java
@@ -24,7 +24,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import java.util.ArrayList;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Base class to check the accessibility of all {@link View}s in a hierarchy.
@@ -53,7 +53,7 @@ public abstract class AccessibilityViewHierarchyCheck extends AccessibilityCheck
    *     empty if the check passes without incident.
    */
   public abstract List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(
-      View root, @Nullable Parameters parameters);
+      View root, @NullableDecl Parameters parameters);
 
   /** @see AccessibilityViewHierarchyCheck#runCheckOnViewHierarchy(View, Parameters) */
   public List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(View root) {
@@ -75,7 +75,7 @@ public abstract class AccessibilityViewHierarchyCheck extends AccessibilityCheck
       View root,
       AccessibilityCheck fromCheck,
       AccessibilityHierarchyCheck toCheck,
-      @Nullable Parameters parameters) {
+      @NullableDecl Parameters parameters) {
 
     // Construct the AccessibilityHierarchyAndroid from the actual view root, as to capture all
     // available information within the view hierarchy.

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/Answer.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/Answer.java
@@ -4,7 +4,7 @@ import com.google.android.apps.common.testing.accessibility.framework.proto.Acce
 import com.google.android.apps.common.testing.accessibility.framework.uielement.AccessibilityHierarchy;
 import com.google.common.annotations.Beta;
 import java.util.Objects;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** A response to a {@link Question} about an {@link AccessibilityHierarchyCheckResult} */
 @Beta
@@ -78,7 +78,7 @@ public class Answer {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(@NullableDecl Object o) {
     if (this == o) {
       return true;
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/ClickableSpanViewCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/ClickableSpanViewCheck.java
@@ -20,7 +20,7 @@ import android.text.style.ClickableSpan;
 import android.view.View;
 import com.google.android.apps.common.testing.accessibility.framework.checks.ClickableSpanCheck;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Check to ensure that {@code ClickableSpan} is not being used in a TextView.
@@ -41,7 +41,7 @@ public class ClickableSpanViewCheck extends AccessibilityViewHierarchyCheck {
 
   @Override
   public List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(
-      View root, @Nullable Parameters parameters) {
+      View root, @NullableDecl Parameters parameters) {
     return super.runDelegationCheckOnView(root, this, DELEGATION_CHECK, parameters);
   }
 }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/ClusteringUtils.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/ClusteringUtils.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.checkerframework.dataflow.qual.Pure;
 
 /**
@@ -59,7 +59,7 @@ public class ClusteringUtils {
 
   public interface ResourceIdGenerator {
     /** Returns a resource identifier for the given element. */
-    @Nullable String apply(ViewHierarchyElement vhe);
+    @NullableDecl String apply(ViewHierarchyElement vhe);
   }
 
   /**
@@ -71,7 +71,13 @@ public class ClusteringUtils {
    * resource name.
    */
   public static final Similarity<AccessibilityHierarchyCheckResult> SIMILAR_RESULTS =
-      new ResultSimilarity(ViewHierarchyElement::getResourceName);
+      new ResultSimilarity(new ResourceIdGenerator() {
+        @NullableDecl
+        @Override
+        public String apply(ViewHierarchyElement vhe) {
+          return vhe.getResourceName();
+        }
+      });
 
   /**
    * A predicate indicating similarity between two {@link AccessibilityHierarchyCheckResult}s.
@@ -89,7 +95,13 @@ public class ClusteringUtils {
    */
   public static final Similarity<AccessibilityHierarchyCheckResult>
       SIMILAR_RESULTS_NEAREST_ANCESTOR_RELATION =
-      new ResultSimilarity(vhe -> getPseudoResourceId(vhe, /* includeIndices= */ true));
+      new ResultSimilarity(new ResourceIdGenerator() {
+        @NullableDecl
+        @Override
+        public String apply(ViewHierarchyElement vhe) {
+          return getPseudoResourceId(vhe, /* includeIndices= */ true);
+        }
+      });
 
   /**
    * A predicate indicating similarity between two {@link AccessibilityHierarchyCheckResult}s.
@@ -108,7 +120,13 @@ public class ClusteringUtils {
    */
   public static final Similarity<AccessibilityHierarchyCheckResult>
       SIMILAR_RESULTS_NEAREST_ANCESTOR_CHAIN =
-      new ResultSimilarity(vhe -> getPseudoResourceId(vhe, /* includeIndices= */ false));
+      new ResultSimilarity(new ResourceIdGenerator() {
+        @NullableDecl
+        @Override
+        public String apply(ViewHierarchyElement vhe) {
+          return getPseudoResourceId(vhe, /* includeIndices= */ false);
+        }
+      });
 
   /**
    * A generalized predicate indicating similarity between two
@@ -202,7 +220,7 @@ public class ClusteringUtils {
    *     has a resource name.
    */
   @Pure
-  public static @Nullable String getPseudoResourceId(
+  public static @NullableDecl String getPseudoResourceId(
       ViewHierarchyElement vhe, boolean includeIndices) {
     if (vhe.getResourceName() != null) {
       return vhe.getResourceName();
@@ -212,7 +230,7 @@ public class ClusteringUtils {
   }
 
   @SuppressWarnings("ReferenceEquality")
-  private static @Nullable StringBuilder getResourceIdBuilder(
+  private static @NullableDecl StringBuilder getResourceIdBuilder(
       ViewHierarchyElement vhe, boolean includeIndices) {
     String resourceName = vhe.getResourceName();
     if (resourceName != null) {
@@ -250,7 +268,7 @@ public class ClusteringUtils {
    * Returns the simple name of the class to which the given view belongs, or {@code null} if one
    * cannot be determined.
    */
-  private static @Nullable CharSequence getShortClassName(ViewHierarchyElement vhe) {
+  private static @NullableDecl CharSequence getShortClassName(ViewHierarchyElement vhe) {
     CharSequence className = vhe.getClassName();
     if (className != null) {
       return simpleClassName(className);

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/DuplicateClickableBoundsViewCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/DuplicateClickableBoundsViewCheck.java
@@ -17,7 +17,7 @@ package com.google.android.apps.common.testing.accessibility.framework;
 import android.view.View;
 import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Developers sometimes have containers marked clickable when they don't process click events. This
@@ -34,7 +34,7 @@ public class DuplicateClickableBoundsViewCheck extends AccessibilityViewHierarch
 
   @Override
   public List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(
-      View root, @Nullable Parameters parameters) {
+      View root, @NullableDecl Parameters parameters) {
     return super.runDelegationCheckOnView(root, this, DELEGATION_CHECK, parameters);
   }
 }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/DuplicateSpeakableTextViewHierarchyCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/DuplicateSpeakableTextViewHierarchyCheck.java
@@ -17,7 +17,7 @@ package com.google.android.apps.common.testing.accessibility.framework;
 import android.view.View;
 import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateSpeakableTextCheck;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * If two Views in a hierarchy have the same speakable text, that could be confusing for users. Two
@@ -35,7 +35,7 @@ public class DuplicateSpeakableTextViewHierarchyCheck extends AccessibilityViewH
 
   @Override
   public List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(
-      View root, @Nullable Parameters parameters) {
+      View root, @NullableDecl Parameters parameters) {
     return super.runDelegationCheckOnView(root, this, DELEGATION_CHECK, parameters);
   }
 }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/EditableContentDescViewCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/EditableContentDescViewCheck.java
@@ -19,7 +19,7 @@ package com.google.android.apps.common.testing.accessibility.framework;
 import android.view.View;
 import com.google.android.apps.common.testing.accessibility.framework.checks.EditableContentDescCheck;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Check to ensure that an editable TextView is not labeled by a contentDescription
@@ -33,7 +33,7 @@ public class EditableContentDescViewCheck extends AccessibilityViewHierarchyChec
 
   @Override
   public List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(
-      View root, @Nullable Parameters parameters) {
+      View root, @NullableDecl Parameters parameters) {
     return super.runDelegationCheckOnView(root, this, DELEGATION_CHECK, parameters);
   }
 }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/HashMapResultMetadata.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/HashMapResultMetadata.java
@@ -20,6 +20,7 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** An implementation of {@link ResultMetadata} backed by a {@link HashMap} */
 public class HashMapResultMetadata implements ResultMetadata {
@@ -382,7 +383,7 @@ public class HashMapResultMetadata implements ResultMetadata {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(@NullableDecl Object o) {
     if (this == o) {
       return true;
     }
@@ -407,7 +408,7 @@ public class HashMapResultMetadata implements ResultMetadata {
   }
 
   @SuppressWarnings("unchecked") // Safe specification in TypedValue
-  private <T> T getValue(String key, TypedValue.Type type, @Nullable T defaultValue) {
+  private <T> T getValue(String key, TypedValue.Type type, @NullableDecl T defaultValue) {
     TypedValue tv = map.get(key);
     if (tv == null) {
       if (defaultValue != null) {
@@ -597,7 +598,7 @@ public class HashMapResultMetadata implements ResultMetadata {
     }
 
     @Override
-    public boolean equals(@Nullable Object o) {
+    public boolean equals(@NullableDecl Object o) {
       if (this == o) {
         return true;
       }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/Parameters.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/Parameters.java
@@ -3,17 +3,17 @@ package com.google.android.apps.common.testing.accessibility.framework;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.Image;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Supplemental input data or preferences for an {@link AccessibilityHierarchyCheck}. */
 public class Parameters {
 
-  @Nullable private Image screenCapture;
-  @Nullable private Double customTextContrastRatio;
-  @Nullable private Double customImageContrastRatio;
-  @Nullable private Integer customTouchTargetSize;
-  @Nullable private Boolean enableEnhancedContrastEvaluation;
-  @Nullable private Boolean saveViewImage;
+  @NullableDecl private Image screenCapture;
+  @NullableDecl private Double customTextContrastRatio;
+  @NullableDecl private Double customImageContrastRatio;
+  @NullableDecl private Integer customTouchTargetSize;
+  @NullableDecl private Boolean enableEnhancedContrastEvaluation;
+  @NullableDecl private Boolean saveViewImage;
 
   public Parameters() {
     super();
@@ -26,7 +26,7 @@ public class Parameters {
    *     was set.
    * @see #putScreenCapture(Image)
    */
-  public @Nullable Image getScreenCapture() {
+  public @NullableDecl Image getScreenCapture() {
     return screenCapture;
   }
 
@@ -57,7 +57,7 @@ public class Parameters {
   }
 
   /** Gets the preference for whether images of the subject Views should be preserved. */
-  public @Nullable Boolean getSaveViewImages() {
+  public @NullableDecl Boolean getSaveViewImages() {
     return saveViewImage;
   }
 
@@ -70,7 +70,7 @@ public class Parameters {
    * @deprecated Use {@link #getCustomTextContrastRatio} and {@link #getCustomImageContrastRatio}
    */
   @Deprecated
-  public @Nullable Double getCustomContrastRatio() {
+  public @NullableDecl Double getCustomContrastRatio() {
     throw new UnsupportedOperationException();
   }
 
@@ -81,7 +81,7 @@ public class Parameters {
    *     has not been set.
    * @see #putCustomTextContrastRatio(double)
    */
-  public @Nullable Double getCustomTextContrastRatio() {
+  public @NullableDecl Double getCustomTextContrastRatio() {
     return customTextContrastRatio;
   }
 
@@ -92,7 +92,7 @@ public class Parameters {
    *     has not been set.
    * @see #putCustomImageContrastRatio(double)
    */
-  public @Nullable Double getCustomImageContrastRatio() {
+  public @NullableDecl Double getCustomImageContrastRatio() {
     return customImageContrastRatio;
   }
 
@@ -142,7 +142,7 @@ public class Parameters {
    *     not been set.
    * @see #putCustomTouchTargetSize(int)
    */
-  public @Nullable Integer getCustomTouchTargetSize() {
+  public @NullableDecl Integer getCustomTouchTargetSize() {
     return customTouchTargetSize;
   }
 
@@ -165,7 +165,7 @@ public class Parameters {
    *     a user-defined value has not been set.
    * @see #putEnhancedContrastEvaluationMode(boolean)
    */
-  public @Nullable Boolean getEnableEnhancedContrastEvaluation() {
+  public @NullableDecl Boolean getEnableEnhancedContrastEvaluation() {
     return enableEnhancedContrastEvaluation;
   }
 

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/Question.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/Question.java
@@ -4,7 +4,7 @@ import com.google.android.apps.common.testing.accessibility.framework.proto.Acce
 import com.google.android.apps.common.testing.accessibility.framework.uielement.AccessibilityHierarchy;
 import com.google.common.annotations.Beta;
 import java.util.Objects;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.checkerframework.dataflow.qual.Pure;
 
 /**
@@ -19,7 +19,7 @@ public class Question {
   private final Class<? extends AnswerType> answerTypeClass;
   private final Class<? extends QuestionHandler> questionHandlerClass;
   private final AccessibilityHierarchyCheckResult originalResult;
-  private final @Nullable ResultMetadata metadata;
+  private final @NullableDecl ResultMetadata metadata;
 
   /**
    * @param questionId the question identifier
@@ -35,7 +35,7 @@ public class Question {
       Class<? extends AnswerType> answerTypeClass,
       QuestionHandler questionHandler,
       AccessibilityHierarchyCheckResult originalResult,
-      @Nullable ResultMetadata metadata) {
+      @NullableDecl ResultMetadata metadata) {
     this.questionId = questionId;
     this.questionTypeClass = questionTypeClass;
     this.answerTypeClass = answerTypeClass;
@@ -58,7 +58,7 @@ public class Question {
       Class<? extends AnswerType> answerTypeClass,
       Class<? extends QuestionHandler> questionHandlerClass,
       AccessibilityHierarchyCheckResult originalResult,
-      @Nullable ResultMetadata metadata) {
+      @NullableDecl ResultMetadata metadata) {
     this.questionId = questionId;
     this.questionTypeClass = questionTypeClass;
     this.answerTypeClass = answerTypeClass;
@@ -102,7 +102,7 @@ public class Question {
    * returns {@code null} if the question id alone is sufficient
    */
   @Pure
-  public @Nullable ResultMetadata getMetadata() {
+  public @NullableDecl ResultMetadata getMetadata() {
     return metadata;
   }
 
@@ -156,7 +156,7 @@ public class Question {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(@NullableDecl Object o) {
     if (this == o) {
       return true;
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/QuestionHandler.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/QuestionHandler.java
@@ -3,7 +3,7 @@ package com.google.android.apps.common.testing.accessibility.framework;
 import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Manages questions, answers, and updating of results related to an {@link
@@ -20,7 +20,7 @@ public abstract class QuestionHandler {
    * Returns the next {@link Question} if the {@link AccessibilityHierarchyCheckResult} has one,
    * else returns {@code null}
    */
-  public abstract @Nullable Question getNextQuestion(AccessibilityHierarchyCheckResult result);
+  public abstract @NullableDecl Question getNextQuestion(AccessibilityHierarchyCheckResult result);
 
   /**
    * Returns the string for the phrasing of the passed question
@@ -67,7 +67,7 @@ public abstract class QuestionHandler {
    * Return a {@link Answer} that answers the question of questionId, if it has been answered, else
    * returns {@code null}. Assumes answers are kept in an ordered list.
    */
-  protected static @Nullable Answer getFirstAnswerForQuestionId(
+  protected static @NullableDecl Answer getFirstAnswerForQuestionId(
       AccessibilityHierarchyCheckResult result, int questionId) {
     for (Answer answer : result.getAnswers()) {
       if (answer.getQuestion().getQuestionId() == questionId) {

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/RedundantContentDescViewCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/RedundantContentDescViewCheck.java
@@ -17,7 +17,7 @@ package com.google.android.apps.common.testing.accessibility.framework;
 import android.view.View;
 import com.google.android.apps.common.testing.accessibility.framework.checks.RedundantDescriptionCheck;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Checks to ensure that speakable text does not contain redundant information about the view's
@@ -34,7 +34,7 @@ public class RedundantContentDescViewCheck extends AccessibilityViewHierarchyChe
 
   @Override
   public List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(
-      View root, @Nullable Parameters parameters) {
+      View root, @NullableDecl Parameters parameters) {
     return super.runDelegationCheckOnView(root, this, DELEGATION_CHECK, parameters);
   }
 }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/SpeakableTextPresentViewCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/SpeakableTextPresentViewCheck.java
@@ -17,7 +17,7 @@ package com.google.android.apps.common.testing.accessibility.framework;
 import android.view.View;
 import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Check to ensure that a view has a content description for a screen reader
@@ -31,7 +31,7 @@ public class SpeakableTextPresentViewCheck extends AccessibilityViewHierarchyChe
 
   @Override
   public List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(
-      View root, @Nullable Parameters parameters) {
+      View root, @NullableDecl Parameters parameters) {
     return super.runDelegationCheckOnView(root, this, DELEGATION_CHECK, parameters);
   }
 }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/TextContrastViewCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/TextContrastViewCheck.java
@@ -17,7 +17,7 @@ package com.google.android.apps.common.testing.accessibility.framework;
 import android.view.View;
 import com.google.android.apps.common.testing.accessibility.framework.checks.TextContrastCheck;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Check to ensure that a TextView has sufficient contrast between text color and background color
@@ -31,7 +31,7 @@ public class TextContrastViewCheck extends AccessibilityViewHierarchyCheck {
 
   @Override
   public List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(
-      View root, @Nullable Parameters parameters) {
+      View root, @NullableDecl Parameters parameters) {
     return super.runDelegationCheckOnView(root, this, DELEGATION_CHECK, parameters);
   }
 }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/TouchTargetSizeViewCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/TouchTargetSizeViewCheck.java
@@ -17,7 +17,7 @@ package com.google.android.apps.common.testing.accessibility.framework;
 import android.view.View;
 import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Check to ensure that a view has a touch target that is at least 48x48dp.
@@ -31,7 +31,7 @@ public class TouchTargetSizeViewCheck extends AccessibilityViewHierarchyCheck {
 
   @Override
   public List<AccessibilityViewCheckResult> runCheckOnViewHierarchy(
-      View root, @Nullable Parameters parameters) {
+      View root, @NullableDecl Parameters parameters) {
     return super.runDelegationCheckOnView(root, this, DELEGATION_CHECK, parameters);
   }
 }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/ViewAccessibilityUtils.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/ViewAccessibilityUtils.java
@@ -32,7 +32,7 @@ import androidx.annotation.RequiresApi;
 import com.google.android.libraries.accessibility.utils.log.LogUtils;
 import java.util.HashSet;
 import java.util.Set;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * This class provides a set of utilities used to evaluate accessibility properties and behaviors of
@@ -186,7 +186,7 @@ public final class ViewAccessibilityUtils {
    * @return The {@code View} that is the labelFor the specified view. {@code null} if nothing
    *     labels it.
    */
-  public static @Nullable View getLabelForView(View view) {
+  public static @NullableDecl View getLabelForView(View view) {
     if ((Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1)) {
       /* Earlier versions don't support labelFor */
       return null;
@@ -223,7 +223,7 @@ public final class ViewAccessibilityUtils {
    * @return {@link Boolean#TRUE} if {@code view} is considered editable, {@link Boolean#FALSE} if
    *     not, or {@code null} if this information cannot be determined.
    */
-  public static @Nullable Boolean isViewEditable(View view) {
+  public static @NullableDecl Boolean isViewEditable(View view) {
     if (view == null) {
       return null;
     }
@@ -242,7 +242,7 @@ public final class ViewAccessibilityUtils {
    *     "package:type/entry", or {@code null} if a resource name does not exist or cannot be
    *     resolved.
    */
-  public static @Nullable String getResourceNameForView(View view) {
+  public static @NullableDecl String getResourceNameForView(View view) {
     if (view == null
         || view.getId() == 0
         || view.getId() == View.NO_ID
@@ -273,8 +273,8 @@ public final class ViewAccessibilityUtils {
   }
 
   @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1) // Calls View#getLabelFor
-  private static @Nullable View lookForLabelForViewInViewAndChildren(
-      View view, @Nullable View childToSkip, int idToFind) {
+  private static @NullableDecl View lookForLabelForViewInViewAndChildren(
+      View view, @NullableDecl View childToSkip, int idToFind) {
     if (view.getLabelFor() == idToFind) {
       return view;
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/ViewHierarchyElementUtils.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/ViewHierarchyElementUtils.java
@@ -12,7 +12,7 @@ import com.google.android.apps.common.testing.accessibility.framework.uielement.
 import com.google.android.apps.common.testing.accessibility.framework.uielement.ViewHierarchyElement;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.WindowHierarchyElement;
 import com.google.common.collect.ImmutableList;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Utility class for initialization and evaluation of ViewHierarchyElements
@@ -301,7 +301,7 @@ public final class ViewHierarchyElementUtils {
    * @return The first important for accessibility {@link ViewHierarchyElement} in {@code view}'s
    * lineage, or {@code null} if no such ancestor exists.
    */
-  private static @Nullable ViewHierarchyElement getImportantForAccessibilityAncestor(
+  private static @NullableDecl ViewHierarchyElement getImportantForAccessibilityAncestor(
       ViewHierarchyElement view) {
     ViewHierarchyElement parent = view.getParentView();
     while ((parent != null) && !view.isImportantForAccessibility()) {

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/ClassNameCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/ClassNameCheck.java
@@ -18,7 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Checks that the {@link ViewHierarchyElement#getAccessibilityClassName()} is supported by
@@ -80,7 +80,7 @@ public class ClassNameCheck extends AccessibilityHierarchyCheck {
           "androidx");
 
   @Override
-  protected @Nullable String getHelpTopic() {
+  protected @NullableDecl String getHelpTopic() {
     return "7661305";
   }
 
@@ -92,8 +92,8 @@ public class ClassNameCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
 
     List<? extends ViewHierarchyElement> viewsToEval = getElementsToEvaluate(fromRoot, hierarchy);
@@ -168,7 +168,7 @@ public class ClassNameCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     switch (resultId) {
       case RESULT_ID_NOT_VISIBLE:
         return StringManager.getString(locale, "result_message_not_visible");
@@ -191,7 +191,7 @@ public class ClassNameCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     switch (resultId) {
       case RESULT_ID_NOT_VISIBLE:
         return StringManager.getString(locale, "result_message_not_visible");

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/ClickableSpanCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/ClickableSpanCheck.java
@@ -33,7 +33,7 @@ import com.google.android.apps.common.testing.accessibility.framework.uielement.
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Check to ensure that {@code ClickableSpan} is not being used in a TextView.
@@ -78,8 +78,8 @@ public class ClickableSpanCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
     if (hierarchy.getDeviceState().getSdkVersion() >= APPLICABLE_UNTIL_ANDROID_SDK_VERSION) {
       results.add(
@@ -128,13 +128,13 @@ public class ClickableSpanCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     return generateMessageForResult(locale, resultId);
   }
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     return generateMessageForResult(locale, resultId);
   }
 

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/DuplicateClickableBoundsCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/DuplicateClickableBoundsCheck.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Developers sometimes have containers marked clickable when they don't process click events. This
@@ -93,8 +93,8 @@ public class DuplicateClickableBoundsCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
 
     /* Find all bounds and the clickable views that have those bounds within the full hierarchy */
@@ -159,7 +159,7 @@ public class DuplicateClickableBoundsCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     // For each of the following result IDs, metadata will have been set on the result, and metadata
     // will contain bounds.
     checkNotNull(metadata);
@@ -186,7 +186,7 @@ public class DuplicateClickableBoundsCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     // For each of the following result IDs, metadata will have been set on the result.
     checkNotNull(metadata);
     String actionString = getShortActionString(
@@ -268,7 +268,7 @@ public class DuplicateClickableBoundsCheck extends AccessibilityHierarchyCheck {
     metadata.putInt(KEY_CONFLICTING_LOCATION_BOTTOM, rect.getBottom());
   }
 
-  private static @Nullable Rect getBoundsFromMetadata(@Nullable ResultMetadata metadata) {
+  private static @NullableDecl Rect getBoundsFromMetadata(@NullableDecl ResultMetadata metadata) {
     if ((metadata != null)
         && metadata.containsKey(KEY_CONFLICTING_LOCATION_LEFT)
         && metadata.containsKey(KEY_CONFLICTING_LOCATION_TOP)
@@ -302,7 +302,7 @@ public class DuplicateClickableBoundsCheck extends AccessibilityHierarchyCheck {
     }
 
     @Override
-    public boolean equals(@Nullable Object obj) {
+    public boolean equals(@NullableDecl Object obj) {
       if (this == obj) {
         return true;
       }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/DuplicateSpeakableTextCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/DuplicateSpeakableTextCheck.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * If two Views in a hierarchy have the same speakable text, that could be confusing for users. Two
@@ -70,8 +70,8 @@ public class DuplicateSpeakableTextCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
 
     /* Find all text and the views that have that text throughout the full hierarchy */
@@ -136,7 +136,7 @@ public class DuplicateSpeakableTextCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     // For each of the following result IDs, metadata will have been set on the result.
     checkNotNull(metadata);
     switch (resultId) {
@@ -170,7 +170,7 @@ public class DuplicateSpeakableTextCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     switch (resultId) {
       case RESULT_ID_CLICKABLE_SAME_SPEAKABLE_TEXT:
       case RESULT_ID_NON_CLICKABLE_SAME_SPEAKABLE_TEXT:
@@ -189,7 +189,7 @@ public class DuplicateSpeakableTextCheck extends AccessibilityHierarchyCheck {
    * repetitions, the higher the priority.
    */
   @Override
-  public @Nullable Double getSecondaryPriority(AccessibilityHierarchyCheckResult result) {
+  public @NullableDecl Double getSecondaryPriority(AccessibilityHierarchyCheckResult result) {
     ResultMetadata metadata = result.getMetadata();
     switch (result.getResultId()) {
       case RESULT_ID_CLICKABLE_SAME_SPEAKABLE_TEXT:

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/EditableContentDescCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/EditableContentDescCheck.java
@@ -30,7 +30,7 @@ import com.google.android.apps.common.testing.accessibility.framework.uielement.
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Check to ensure that an editable TextView is not labeled by a contentDescription
@@ -57,8 +57,8 @@ public class EditableContentDescCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
     List<? extends ViewHierarchyElement> viewsToEval = getElementsToEvaluate(fromRoot, hierarchy);
     for (ViewHierarchyElement view : viewsToEval) {
@@ -95,13 +95,13 @@ public class EditableContentDescCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     return generateMessageForResultId(locale, resultId);
   }
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     return generateMessageForResultId(locale, resultId);
   }
 

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/ImageContrastCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/ImageContrastCheck.java
@@ -34,11 +34,12 @@ import com.google.android.apps.common.testing.accessibility.framework.utils.cont
 import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.ContrastUtils;
 import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.Image;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Check that ensures image foregrounds have sufficient contrast against their background
@@ -111,8 +112,8 @@ public class ImageContrastCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
     List<? extends ViewHierarchyElement> viewsToEval = getElementsToEvaluate(fromRoot, hierarchy);
     for (ViewHierarchyElement view : viewsToEval) {
@@ -169,9 +170,9 @@ public class ImageContrastCheck extends AccessibilityHierarchyCheck {
    * @return an {@link AccessibilityHierarchyCheckResult} describing the results of the heavyweight
    *     evaluation, or {@code null} if there is no problem detected.
    */
-  @Nullable
+  @NullableDecl
   private AccessibilityHierarchyCheckResult attemptHeavyweightEval(
-      ViewHierarchyElement view, @Nullable Parameters parameters) {
+      ViewHierarchyElement view, @NullableDecl Parameters parameters) {
     Image screenCapture = (parameters == null) ? null : parameters.getScreenCapture();
     if (screenCapture == null) {
       return new AccessibilityHierarchyCheckResult(
@@ -285,7 +286,7 @@ public class ImageContrastCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     String generated = generateMessageForResultId(locale, resultId);
     if (generated != null) {
       return generated;
@@ -334,7 +335,7 @@ public class ImageContrastCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     String generated = generateMessageForResultId(locale, resultId);
     if (generated != null) {
       return generated;
@@ -359,7 +360,7 @@ public class ImageContrastCheck extends AccessibilityHierarchyCheck {
    * for a given required contrast ratio, decreasing contrast gives a higher priority.
    */
   @Override
-  public @Nullable Double getSecondaryPriority(AccessibilityHierarchyCheckResult result) {
+  public @NullableDecl Double getSecondaryPriority(AccessibilityHierarchyCheckResult result) {
     ResultMetadata metadata = result.getMetadata();
     switch (result.getResultId()) {
       case RESULT_ID_IMAGE_CONTRAST_NOT_SUFFICIENT:
@@ -380,7 +381,7 @@ public class ImageContrastCheck extends AccessibilityHierarchyCheck {
 
   @VisibleForTesting
   ContrastSwatch getContrastSwatch(
-      Image image, @Nullable Boolean enableEnhancedContrastEvaluation) {
+      Image image, @NullableDecl Boolean enableEnhancedContrastEvaluation) {
     return new ContrastSwatch(
         image,
         (enableEnhancedContrastEvaluation == null) ? false : enableEnhancedContrastEvaluation);
@@ -401,8 +402,8 @@ public class ImageContrastCheck extends AccessibilityHierarchyCheck {
       ViewHierarchyElement view,
       int resultId,
       ResultMetadata metadata,
-      @Nullable Parameters parameters,
-      @Nullable Image viewImage) {
+      @NullableDecl Parameters parameters,
+      @NullableDecl Image viewImage) {
     if ((viewImage != null)
         && (parameters != null)
         && Boolean.TRUE.equals(parameters.getSaveViewImages())) {
@@ -436,7 +437,14 @@ public class ImageContrastCheck extends AccessibilityHierarchyCheck {
       resultMetadata.putStringList(
           KEY_ADDITIONAL_FOREGROUND_COLORS,
           Lists.transform(
-              foregroundColors.subList(1, foregroundColors.size()), integer -> integer.toString()));
+              foregroundColors.subList(1, foregroundColors.size()),
+              new Function<Integer, String>() {
+                @NullableDecl
+                @Override
+                public String apply(@NullableDecl Integer integer) {
+                  return integer.toString();
+                }
+              }));
     }
   }
 
@@ -452,7 +460,13 @@ public class ImageContrastCheck extends AccessibilityHierarchyCheck {
       resultMetadata.putStringList(
           KEY_ADDITIONAL_CONTRAST_RATIOS,
           Lists.transform(
-              contrastRatios.subList(1, contrastRatios.size()), ratio -> ratio.toString()));
+              contrastRatios.subList(1, contrastRatios.size()), new Function<Double, String>() {
+                @NullableDecl
+                @Override
+                public String apply(@NullableDecl Double ratio) {
+                  return ratio.toString();
+                }
+              }));
     }
   }
 
@@ -480,7 +494,7 @@ public class ImageContrastCheck extends AccessibilityHierarchyCheck {
     }
   }
 
-  private static @Nullable String generateMessageForResultId(Locale locale, int resultId) {
+  private static @NullableDecl String generateMessageForResultId(Locale locale, int resultId) {
     switch (resultId) {
       case RESULT_ID_NOT_VISIBLE:
         return StringManager.getString(locale, "result_message_not_visible");

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/LinkPurposeUnclearCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/LinkPurposeUnclearCheck.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Check to warn about a link (ClickableSpan) whose purpose is unclear. */
 public class LinkPurposeUnclearCheck extends AccessibilityHierarchyCheck {
@@ -64,7 +64,7 @@ public class LinkPurposeUnclearCheck extends AccessibilityHierarchyCheck {
   private static final Pattern WORD_PATTERN = Pattern.compile("\\w+");
 
   @Override
-  @Nullable
+  @NullableDecl
   protected String getHelpTopic() {
     return "9663312"; // Link purpose unclear
   }
@@ -77,8 +77,8 @@ public class LinkPurposeUnclearCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
 
     if (!isEnglish(hierarchy)) {
@@ -153,7 +153,7 @@ public class LinkPurposeUnclearCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     String generated = generateMessageForResultId(locale, resultId);
     if (generated != null) {
       return generated;
@@ -174,7 +174,7 @@ public class LinkPurposeUnclearCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     String generated = generateMessageForResultId(locale, resultId);
     if (generated != null) {
       return generated;
@@ -193,7 +193,7 @@ public class LinkPurposeUnclearCheck extends AccessibilityHierarchyCheck {
     return StringManager.getString(locale, "check_title_link_test");
   }
 
-  @Nullable
+  @NullableDecl
   private static String generateMessageForResultId(Locale locale, int resultId) {
     switch (resultId) {
       case RESULT_ID_ENGLISH_LOCALE_ONLY:

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/RedundantDescriptionCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/RedundantDescriptionCheck.java
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Checks for speakable text that may contain redundant or inappropriate information:
@@ -115,8 +115,8 @@ public class RedundantDescriptionCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
     Locale recordedLocale = getRecordedLocale(hierarchy);
 
@@ -222,7 +222,7 @@ public class RedundantDescriptionCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     String generated = generateMessageForResultId(locale, resultId);
     if (generated != null) {
       return generated;
@@ -261,7 +261,7 @@ public class RedundantDescriptionCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     String generated = generateMessageForResultId(locale, resultId);
     if (generated != null) {
       return generated;
@@ -296,7 +296,7 @@ public class RedundantDescriptionCheck extends AccessibilityHierarchyCheck {
     return hierarchy.getDeviceState().getLocale();
   }
 
-  private static @Nullable String generateMessageForResultId(Locale locale, int resultId) {
+  private static @NullableDecl String generateMessageForResultId(Locale locale, int resultId) {
     switch (resultId) {
       case RESULT_ID_NOT_VISIBLE:
         return StringManager.getString(locale, "result_message_not_visible");

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/SpeakableTextPresentCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/SpeakableTextPresentCheck.java
@@ -30,7 +30,7 @@ import com.google.android.apps.common.testing.accessibility.framework.uielement.
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Checks that items that require speakable text have some. Does not check if the text makes sense.
@@ -61,8 +61,8 @@ public class SpeakableTextPresentCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
     List<? extends ViewHierarchyElement> viewsToEval = getElementsToEvaluate(fromRoot, hierarchy);
     for (ViewHierarchyElement element : viewsToEval) {
@@ -121,13 +121,13 @@ public class SpeakableTextPresentCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     return generateMessageForResultId(locale, resultId);
   }
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     return generateMessageForResultId(locale, resultId);
   }
 

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/TextContrastCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/TextContrastCheck.java
@@ -38,11 +38,12 @@ import com.google.android.apps.common.testing.accessibility.framework.utils.cont
 import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.ContrastUtils;
 import com.google.android.apps.common.testing.accessibility.framework.utils.contrast.Image;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Check that ensures text content has sufficient contrast against its background */
 public class TextContrastCheck extends AccessibilityHierarchyCheck {
@@ -145,8 +146,8 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
     List<? extends ViewHierarchyElement> viewsToEval = getElementsToEvaluate(fromRoot, hierarchy);
     for (ViewHierarchyElement view : viewsToEval) {
@@ -218,7 +219,7 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     String generated = generateMessageForResultId(locale, resultId);
     if (generated != null) {
       return generated;
@@ -322,7 +323,7 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     String generated = generateMessageForResultId(locale, resultId);
     if (generated != null) {
       return generated;
@@ -352,7 +353,7 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
    * for a given required contrast ratio, decreasing contrast gives a higher priority.
    */
   @Override
-  public @Nullable Double getSecondaryPriority(AccessibilityHierarchyCheckResult result) {
+  public @NullableDecl Double getSecondaryPriority(AccessibilityHierarchyCheckResult result) {
     ResultMetadata metadata = result.getMetadata();
     switch (result.getResultId()) {
       case RESULT_ID_TEXTVIEW_CONTRAST_NOT_SUFFICIENT:
@@ -373,7 +374,7 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
     return StringManager.getString(locale, "check_title_text_contrast");
   }
 
-  private static @Nullable String generateMessageForResultId(Locale locale, int resultId) {
+  private static @NullableDecl String generateMessageForResultId(Locale locale, int resultId) {
     switch (resultId) {
       case RESULT_ID_NOT_VISIBLE:
         return StringManager.getString(locale, "result_message_not_visible");
@@ -407,7 +408,7 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
    * @return an {@link AccessibilityHierarchyCheckResult} describing the result of the lightweight
    *     evaluation, or {@code null} if there is sufficient text contrast.
    */
-  private @Nullable AccessibilityHierarchyCheckResult attemptLightweightEval(
+  private @NullableDecl AccessibilityHierarchyCheckResult attemptLightweightEval(
       ViewHierarchyElement view) {
     Integer textColor = getForegroundColor(view);
     Integer backgroundDrawableColor = view.getBackgroundDrawableColor();
@@ -489,8 +490,8 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
    * @return an {@link AccessibilityHierarchyCheckResult} describing the results of the heavyweight
    *     evaluation, or {@code null} if there is sufficient text contrast.
    */
-  private @Nullable AccessibilityHierarchyCheckResult attemptHeavyweightEval(
-      ViewHierarchyElement view, @Nullable Parameters parameters) {
+  private @NullableDecl AccessibilityHierarchyCheckResult attemptHeavyweightEval(
+      ViewHierarchyElement view, @NullableDecl Parameters parameters) {
     Image screenCapture = (parameters == null) ? null : parameters.getScreenCapture();
     if (screenCapture == null) {
       return new AccessibilityHierarchyCheckResult(
@@ -637,7 +638,7 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
 
   @VisibleForTesting
   ContrastSwatch getContrastSwatch(
-      Image image, @Nullable Boolean enableEnhancedContrastEvaluation) {
+      Image image, @NullableDecl Boolean enableEnhancedContrastEvaluation) {
     return new ContrastSwatch(image, Boolean.TRUE.equals(enableEnhancedContrastEvaluation));
   }
 
@@ -675,8 +676,8 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
       ViewHierarchyElement view,
       int resultId,
       ResultMetadata metadata,
-      @Nullable Parameters parameters,
-      @Nullable Image viewImage) {
+      @NullableDecl Parameters parameters,
+      @NullableDecl Image viewImage) {
     if ((viewImage != null)
         && (parameters != null)
         && Boolean.TRUE.equals(parameters.getSaveViewImages())) {
@@ -710,7 +711,14 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
       resultMetadata.putStringList(
           KEY_ADDITIONAL_FOREGROUND_COLORS,
           Lists.transform(
-              foregroundColors.subList(1, foregroundColors.size()), integer -> integer.toString()));
+              foregroundColors.subList(1, foregroundColors.size()),
+              new Function<Integer, String>() {
+                @NullableDecl
+                @Override
+                public String apply(@NullableDecl Integer integer) {
+                  return integer.toString();
+                }
+              }));
     }
   }
 
@@ -725,7 +733,13 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
       resultMetadata.putStringList(
           KEY_ADDITIONAL_CONTRAST_RATIOS,
           Lists.transform(
-              contrastRatios.subList(1, contrastRatios.size()), ratio -> ratio.toString()));
+              contrastRatios.subList(1, contrastRatios.size()), new Function<Double, String>() {
+                @NullableDecl
+                @Override
+                public String apply(@NullableDecl Double ratio) {
+                  return ratio.toString();
+                }
+              }));
     }
   }
 
@@ -773,7 +787,7 @@ public class TextContrastCheck extends AccessibilityHierarchyCheck {
    * Returns the current color selected to paint the text or the hint of the given {@link
    * ViewHierarchyElement}.
    */
-  private static @Nullable Integer getForegroundColor(ViewHierarchyElement view) {
+  private static @NullableDecl Integer getForegroundColor(ViewHierarchyElement view) {
     return TextUtils.isEmpty(view.getText()) ? view.getHintTextColor() : view.getTextColor();
   }
 }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/TouchTargetSizeCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/TouchTargetSizeCheck.java
@@ -35,7 +35,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Check ensuring touch targets have a minimum size, 48x48dp by default
@@ -172,8 +172,8 @@ public class TouchTargetSizeCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
 
     DisplayInfo defaultDisplay = hierarchy.getDeviceState().getDefaultDisplayInfo();
@@ -335,7 +335,7 @@ public class TouchTargetSizeCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     String generated = generateMessageForResultId(locale, resultId);
     if (generated != null) {
       return generated;
@@ -405,7 +405,7 @@ public class TouchTargetSizeCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     String generated = generateMessageForResultId(locale, resultId);
     if (generated != null) {
       return generated;
@@ -440,7 +440,7 @@ public class TouchTargetSizeCheck extends AccessibilityHierarchyCheck {
    */
 
   @Override
-  public @Nullable Double getSecondaryPriority(AccessibilityHierarchyCheckResult result) {
+  public @NullableDecl Double getSecondaryPriority(AccessibilityHierarchyCheckResult result) {
     ResultMetadata meta = result.getMetadata();
     if (meta == null) {
       return null;
@@ -462,7 +462,7 @@ public class TouchTargetSizeCheck extends AccessibilityHierarchyCheck {
     return StringManager.getString(locale, "check_title_touch_target_size");
   }
 
-  private static @Nullable String generateMessageForResultId(Locale locale, int resultId) {
+  private static @NullableDecl String generateMessageForResultId(Locale locale, int resultId) {
     switch (resultId) {
       case RESULT_ID_NOT_CLICKABLE:
         return StringManager.getString(locale, "result_message_not_clickable");
@@ -481,7 +481,7 @@ public class TouchTargetSizeCheck extends AccessibilityHierarchyCheck {
    * @return a {@link Point} representing the minimum allowable size for {@code view} in dp units
    */
   private static Point getMinimumAllowableSizeForView(
-      ViewHierarchyElement view, @Nullable Parameters parameters) {
+      ViewHierarchyElement view, @NullableDecl Parameters parameters) {
     Rect bounds = view.getBoundsInScreen();
     Metrics realMetrics = view.getWindow().getAccessibilityHierarchy().getDeviceState()
         .getDefaultDisplayInfo().getRealMetrics();
@@ -579,7 +579,7 @@ public class TouchTargetSizeCheck extends AccessibilityHierarchyCheck {
    * Returns the largest hit-Rect (by area) in screen coordinates (px units) associated with {@code
    * view}, or {@code null} if no hit-Rects are used
    */
-  @Nullable
+  @NullableDecl
   private static Rect getLargestTouchDelegateHitRect(ViewHierarchyElement view) {
     int largestArea = -1;
     Rect largestHitRect = null;
@@ -621,7 +621,7 @@ public class TouchTargetSizeCheck extends AccessibilityHierarchyCheck {
    *     long-clickable and meets its minimum allowable size.
    */
   private static boolean hasQualifyingClickableAncestor(
-      ViewHierarchyElement view, @Nullable Parameters parameters) {
+      ViewHierarchyElement view, @NullableDecl Parameters parameters) {
     boolean isTargetClickable = TRUE.equals(view.isClickable());
     boolean isTargetLongClickable = TRUE.equals(view.isLongClickable());
     ViewHierarchyElement evalView = view.getParentView();

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/TraversalOrderCheck.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/checks/TraversalOrderCheck.java
@@ -30,7 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Check to detect problems in the developer specified accessibility traversal ordering. */
 public class TraversalOrderCheck extends AccessibilityHierarchyCheck {
@@ -47,7 +47,7 @@ public class TraversalOrderCheck extends AccessibilityHierarchyCheck {
   public static final int RESULT_ID_TRAVERSAL_OVER_CONSTRAINED = 5;
 
   @Override
-  protected @Nullable String getHelpTopic() {
+  protected @NullableDecl String getHelpTopic() {
     return "7664232";
   }
 
@@ -59,8 +59,8 @@ public class TraversalOrderCheck extends AccessibilityHierarchyCheck {
   @Override
   public List<AccessibilityHierarchyCheckResult> runCheckOnHierarchy(
       AccessibilityHierarchy hierarchy,
-      @Nullable ViewHierarchyElement fromRoot,
-      @Nullable Parameters parameters) {
+      @NullableDecl ViewHierarchyElement fromRoot,
+      @NullableDecl Parameters parameters) {
     List<AccessibilityHierarchyCheckResult> results = new ArrayList<>();
     List<? extends ViewHierarchyElement> viewsToEval = getElementsToEvaluate(fromRoot, hierarchy);
     for (ViewHierarchyElement view : viewsToEval) {
@@ -89,7 +89,13 @@ public class TraversalOrderCheck extends AccessibilityHierarchyCheck {
       List<ViewHierarchyElement> beforeChain;
       List<ViewHierarchyElement> afterChain;
       try {
-        beforeChain = buildNodeChain(view, (el) -> el.getAccessibilityTraversalBefore());
+        beforeChain = buildNodeChain(view, new NextElementFunction() {
+          @NullableDecl
+          @Override
+          public ViewHierarchyElement apply(ViewHierarchyElement el) {
+            return el.getAccessibilityTraversalBefore();
+          }
+        });
       } catch (CycleException e) {
         results.add(
             new AccessibilityHierarchyCheckResult(
@@ -101,7 +107,13 @@ public class TraversalOrderCheck extends AccessibilityHierarchyCheck {
         continue;
       }
       try {
-        afterChain = buildNodeChain(view, (el) -> el.getAccessibilityTraversalAfter());
+        afterChain = buildNodeChain(view, new NextElementFunction() {
+          @NullableDecl
+          @Override
+          public ViewHierarchyElement apply(ViewHierarchyElement el) {
+            return el.getAccessibilityTraversalAfter();
+          }
+        });
       } catch (CycleException e) {
         results.add(
             new AccessibilityHierarchyCheckResult(
@@ -132,13 +144,13 @@ public class TraversalOrderCheck extends AccessibilityHierarchyCheck {
 
   @Override
   public String getMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     return generateMessageForResultId(locale, resultId);
   }
 
   @Override
   public String getShortMessageForResultData(
-      Locale locale, int resultId, @Nullable ResultMetadata metadata) {
+      Locale locale, int resultId, @NullableDecl ResultMetadata metadata) {
     switch(resultId) {
       case RESULT_ID_NOT_VISIBLE:
         return StringManager.getString(locale, "result_message_not_visible");
@@ -208,7 +220,7 @@ public class TraversalOrderCheck extends AccessibilityHierarchyCheck {
   }
 
   private interface NextElementFunction {
-    @Nullable ViewHierarchyElement apply(ViewHierarchyElement el);
+    @NullableDecl ViewHierarchyElement apply(ViewHierarchyElement el);
   }
 
   private static class CycleException extends Exception {

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/integrations/espresso/AccessibilityValidator.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/integrations/espresso/AccessibilityValidator.java
@@ -30,11 +30,12 @@ import com.google.android.apps.common.testing.accessibility.framework.Accessibil
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityViewHierarchyCheck;
 import com.google.android.apps.common.testing.accessibility.framework.Parameters;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.hamcrest.Matcher;
 
 /**
@@ -49,16 +50,16 @@ public final class AccessibilityValidator {
   private AccessibilityCheckPreset preset = AccessibilityCheckPreset.LATEST;
   private boolean runChecksFromRootView = false;
 
-  @Nullable
+  @NullableDecl 
   private AccessibilityCheckResultType throwExceptionFor = AccessibilityCheckResultType.ERROR;
 
   // Either resultDescriptor or deprecatedResultDescriptor must have a non-null value, but not both.
-  private AccessibilityCheckResult.@Nullable AccessibilityCheckResultDescriptor
+  private @NullableDecl  AccessibilityCheckResult. AccessibilityCheckResultDescriptor
       deprecatedResultDescriptor = null;
-  private @Nullable AccessibilityCheckResultDescriptor resultDescriptor =
+  private @NullableDecl  AccessibilityCheckResultDescriptor resultDescriptor =
       new AccessibilityCheckResultDescriptor();
 
-  @Nullable private Matcher<? super AccessibilityViewCheckResult> suppressingMatcher = null;
+  @NullableDecl  private Matcher<? super AccessibilityViewCheckResult> suppressingMatcher = null;
   private final List<AccessibilityCheckListener> checkListeners = new ArrayList<>();
 
   public AccessibilityValidator() {
@@ -121,7 +122,7 @@ public final class AccessibilityValidator {
    * @return this
    */
   public AccessibilityValidator setSuppressingResultMatcher(
-      @Nullable Matcher<? super AccessibilityViewCheckResult> resultMatcher) {
+      @NullableDecl Matcher<? super AccessibilityViewCheckResult> resultMatcher) {
       suppressingMatcher = resultMatcher;
     return this;
   }
@@ -157,7 +158,7 @@ public final class AccessibilityValidator {
    * @return this
    */
   public AccessibilityValidator setThrowExceptionFor(
-      @Nullable AccessibilityCheckResultType throwFor) {
+      @NullableDecl AccessibilityCheckResultType throwFor) {
     checkArgument(
         (throwFor == AccessibilityCheckResultType.ERROR)
             || (throwFor == AccessibilityCheckResultType.WARNING)
@@ -302,13 +303,19 @@ public final class AccessibilityValidator {
   @VisibleForTesting
   static ImmutableList<AccessibilityViewCheckResult> suppressMatchingResults(
       List<AccessibilityViewCheckResult> results,
-      @Nullable Matcher<? super AccessibilityViewCheckResult> matcher) {
+      final @NullableDecl Matcher<? super AccessibilityViewCheckResult> matcher) {
     if (matcher == null) {
       return ImmutableList.copyOf(results);
     }
 
-    return FluentIterable.from(results)
-        .transform(result -> matcher.matches(result) ? result.getSuppressedResultCopy() : result)
+    return FluentIterable.<AccessibilityViewCheckResult>from(results)
+        .transform(new Function<AccessibilityViewCheckResult, AccessibilityViewCheckResult>() {
+          @NullableDecl
+          @Override
+          public AccessibilityViewCheckResult apply(@NullableDecl AccessibilityViewCheckResult result) {
+            return matcher.matches(result) ? result.getSuppressedResultCopy() : result;
+          }
+        })
         .toList();
   }
 

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/integrations/espresso/AccessibilityViewCheckException.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/integrations/espresso/AccessibilityViewCheckException.java
@@ -22,7 +22,7 @@ import com.google.android.apps.common.testing.accessibility.framework.Accessibil
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityViewCheckResult;
 import java.util.List;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** An exception class to be used for throwing exceptions with accessibility results. */
 @SuppressWarnings("deprecation")
@@ -31,8 +31,8 @@ public final class AccessibilityViewCheckException
         .AccessibilityViewCheckException {
 
   // Either resultDescriptor or deprecatedResultDescriptor must have a non-null value, but not both.
-  private final @Nullable AccessibilityCheckResultDescriptor resultDescriptor;
-  private final AccessibilityCheckResult.@Nullable AccessibilityCheckResultDescriptor
+  private final @NullableDecl AccessibilityCheckResultDescriptor resultDescriptor;
+  private final @NullableDecl  AccessibilityCheckResult.AccessibilityCheckResultDescriptor
       deprecatedResultDescriptor;
 
   /** Create an instance with the default {@link AccessibilityCheckResultDescriptor} */
@@ -69,8 +69,8 @@ public final class AccessibilityViewCheckException
 
   private AccessibilityViewCheckException(
       List<AccessibilityViewCheckResult> results,
-      @Nullable AccessibilityCheckResultDescriptor resultDescriptor,
-      AccessibilityCheckResult.@Nullable AccessibilityCheckResultDescriptor
+      @NullableDecl AccessibilityCheckResultDescriptor resultDescriptor,
+      AccessibilityCheckResult.AccessibilityCheckResultDescriptor
           deprecatedResultDescriptor) {
     super(results);
     checkArgument(

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/LayoutParams.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/LayoutParams.java
@@ -1,7 +1,7 @@
 package com.google.android.apps.common.testing.accessibility.framework.replacements;
 
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AndroidFrameworkProtos.LayoutParamsProto;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Used as a local immutable replacement for Android's {@link android.view.ViewGroup.LayoutParams}
@@ -42,7 +42,7 @@ public final class LayoutParams {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(@NullableDecl Object o) {
     if (this == o) {
       return true;
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/Point.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/Point.java
@@ -14,7 +14,7 @@
 
 package com.google.android.apps.common.testing.accessibility.framework.replacements;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Used as a local immutable replacement for Android's {@link android.graphics.Point} */
 public final class Point {
@@ -38,7 +38,7 @@ public final class Point {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(@NullableDecl Object o) {
     if (this == o) {
       return true;
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/Rect.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/Rect.java
@@ -18,7 +18,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AndroidFrameworkProtos.RectProto;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Used as a local immutable replacement for Android's {@link android.graphics.Rect} */
 public final class Rect {
@@ -142,7 +142,7 @@ public final class Rect {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(@NullableDecl Object o) {
     if (this == o) {
       return true;
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/SpannableString.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/SpannableString.java
@@ -63,7 +63,7 @@ public class SpannableString implements CharSequence {
   }
 
   protected SpannableString(CharSequence rawString) {
-    this(rawString, ImmutableList.of());
+    this(rawString, ImmutableList.<Span>of());
   }
 
   /**

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/SpannableStringAndroid.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/SpannableStringAndroid.java
@@ -17,7 +17,7 @@ package com.google.android.apps.common.testing.accessibility.framework.replaceme
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Used as a local replacement for Android's {@link android.text.SpannableString} */
 public class SpannableStringAndroid extends SpannableString {
@@ -42,8 +42,8 @@ public class SpannableStringAndroid extends SpannableString {
    * @return A {@link SpannableStringAndroid} with data matching {@code source}, or {@code null} if
    *     {@code source} is {@code null} or empty.
    */
-  @Nullable
-  public static SpannableStringAndroid valueOf(@Nullable CharSequence source) {
+  @NullableDecl
+  public static SpannableStringAndroid valueOf(@NullableDecl CharSequence source) {
     if (TextUtils.isEmpty(source)) {
       return null;
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/SpannableStringBuilder.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/SpannableStringBuilder.java
@@ -4,8 +4,8 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** A fairly lightweight local replacement for {@link android.text.SpannableStringBuilder} */
 public class SpannableStringBuilder implements CharSequence {
@@ -13,11 +13,11 @@ public class SpannableStringBuilder implements CharSequence {
   private static final String SEPARATOR = ", ";
 
   private final StringBuilder rawTextBuilder = new StringBuilder();
-  private @MonotonicNonNull List<Span> spans;
+  private @MonotonicNonNullDecl List<Span> spans;
 
   public SpannableStringBuilder() {}
 
-  public SpannableStringBuilder append(@Nullable SpannableString string) {
+  public SpannableStringBuilder append(@NullableDecl SpannableString string) {
     if (!TextUtils.isEmpty(string)) {
       copyAndAppendAdjustedSpans(string.getSpans(), 0);
       append(string.toString());
@@ -25,14 +25,14 @@ public class SpannableStringBuilder implements CharSequence {
     return this;
   }
 
-  public SpannableStringBuilder append(@Nullable String string) {
+  public SpannableStringBuilder append(@NullableDecl String string) {
     if (!TextUtils.isEmpty(string)) {
       rawTextBuilder.append(string);
     }
     return this;
   }
 
-  public SpannableStringBuilder appendWithSeparator(@Nullable SpannableString string) {
+  public SpannableStringBuilder appendWithSeparator(@NullableDecl SpannableString string) {
     if (!TextUtils.isEmpty(string)) {
       copyAndAppendAdjustedSpans(string.getSpans(), (needsSeparator() ? SEPARATOR.length() : 0));
       appendWithSeparator(string.toString());
@@ -40,7 +40,7 @@ public class SpannableStringBuilder implements CharSequence {
     return this;
   }
 
-  public SpannableStringBuilder appendWithSeparator(@Nullable String string) {
+  public SpannableStringBuilder appendWithSeparator(@NullableDecl String string) {
     if (!TextUtils.isEmpty(string)) {
       if (needsSeparator()) {
         append(SEPARATOR);
@@ -51,7 +51,7 @@ public class SpannableStringBuilder implements CharSequence {
   }
 
   public List<Span> getSpans() {
-    return (spans == null) ? ImmutableList.of() : Collections.unmodifiableList(spans);
+    return (spans == null) ? ImmutableList.<Span>of() : Collections.unmodifiableList(spans);
   }
 
   public SpannableString build() {

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/Spans.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/Spans.java
@@ -2,7 +2,7 @@ package com.google.android.apps.common.testing.accessibility.framework.replaceme
 
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AndroidFrameworkProtos.SpanProto;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AndroidFrameworkProtos.SpanProto.SpanType;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Types of spans that are known and usable within {@link
@@ -54,9 +54,9 @@ public final class Spans {
 
     public static final String ANDROID_CLASS_NAME = "android.text.style.URLSpan";
 
-    private final @Nullable String url;
+    private final @NullableDecl String url;
 
-    public URLSpan(String spanClass, int start, int end, int flags, @Nullable String url) {
+    public URLSpan(String spanClass, int start, int end, int flags, @NullableDecl String url) {
       super(spanClass, start, end, flags);
       this.url = url;
     }
@@ -67,7 +67,7 @@ public final class Spans {
     }
 
     /** @see android.text.style.URLSpan#getURL() */
-    public @Nullable String getUrl() {
+    public @NullableDecl String getUrl() {
       return url;
     }
 

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/TextUtils.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/replacements/TextUtils.java
@@ -14,8 +14,8 @@
 
 package com.google.android.apps.common.testing.accessibility.framework.replacements;
 
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Used as a local replacement for Android's {@link android.text.TextUtils} */
 public class TextUtils {
@@ -26,8 +26,8 @@ public class TextUtils {
   /**
    * @see android.text.TextUtils#isEmpty(CharSequence)
    */
-  @EnsuresNonNullIf(expression = "#1", result = false)
-  public static boolean isEmpty(@Nullable CharSequence str) {
+  //@EnsuresNonNullIf(expression = "#1", result = false)
+  public static boolean isEmpty(@NullableDecl CharSequence str) {
     return (str == null) || (str.length() == 0);
   }
 
@@ -37,7 +37,7 @@ public class TextUtils {
   }
 
   /** See {@link android.text.TextUtils#equals(CharSequence, CharSequence)}. */
-  public static boolean equals(@Nullable CharSequence s1, @Nullable CharSequence s2) {
+  public static boolean equals(@NullableDecl CharSequence s1, @NullableDecl CharSequence s2) {
     if (s1 == s2) {
       return true;
     }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/strings/AndroidXMLResourceBundle.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/strings/AndroidXMLResourceBundle.java
@@ -17,7 +17,7 @@ import java.util.ResourceBundle;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -42,7 +42,7 @@ public class AndroidXMLResourceBundle extends ResourceBundle {
   }
 
   @Override
-  protected @Nullable Object handleGetObject(String key) {
+  protected @NullableDecl Object handleGetObject(String key) {
     return properties.getProperty(key);
   }
 
@@ -96,7 +96,7 @@ public class AndroidXMLResourceBundle extends ResourceBundle {
   }
 
   /** Gets the value of 'name' attribute of an Android style {@code <string>} element. */
-  private static @Nullable String getStringName(Node node) {
+  private static @NullableDecl String getStringName(Node node) {
     NamedNodeMap attributes = node.getAttributes();
     if (attributes != null) {
       Node nameNode = attributes.getNamedItem(ANDROID_STRING_NAME_ATTRIBUTE);
@@ -108,7 +108,7 @@ public class AndroidXMLResourceBundle extends ResourceBundle {
   }
 
   /** Gets the value of an Android style {@code <string>} element. */
-  private static @Nullable String getStringValue(Node node) {
+  private static @NullableDecl String getStringValue(Node node) {
     String value = node.getTextContent();
     if (value == null) {
       return null;
@@ -141,7 +141,7 @@ public class AndroidXMLResourceBundle extends ResourceBundle {
     }
 
     @Override
-    public @Nullable ResourceBundle newBundle(
+    public @NullableDecl ResourceBundle newBundle(
         String baseName, Locale locale, String format, ClassLoader loader, boolean reload)
         throws IllegalAccessException, InstantiationException, IOException {
       String resource = toResourceName(toBundleName(baseName, locale), XML_FORMAT);
@@ -166,7 +166,7 @@ public class AndroidXMLResourceBundle extends ResourceBundle {
     }
 
     @Override
-    public @Nullable Locale getFallbackLocale(String baseName, Locale locale) {
+    public @NullableDecl Locale getFallbackLocale(String baseName, Locale locale) {
       // When android has no corresponding locale, it falls back to the ROOT (values/), so this
       // should not fall back to Locale.getDefault() for parity
       return null;

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/strings/StringManager.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/strings/StringManager.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Manager for obtaining localized strings.
@@ -15,7 +15,7 @@ public final class StringManager {
   private static final String STRINGS_PACKAGE_NAME =
       "com.google.android.apps.common.testing.accessibility.framework";
   private static final String STRINGS_FILE_NAME = "strings";
-  private static @Nullable ResourceBundleProvider resourceBundleProvider;
+  private static @NullableDecl ResourceBundleProvider resourceBundleProvider;
 
   private StringManager() {
   }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/AccessibilityHierarchy.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/AccessibilityHierarchy.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Representation of a UI hierarchy for accessibility checking
@@ -173,13 +173,13 @@ public class AccessibilityHierarchy {
     }
 
     /** Returns an identifier associated with a given class name. Returns null if not found. */
-    @Nullable
+    @NullableDecl
     public Integer getIdentifierForClassName(String className) {
       return uniqueViewElementsClassNames.get(className);
     }
 
     /** Returns a class name associated with a given identifier. Returns null if not found. */
-    @Nullable
+    @NullableDecl
     public String getClassNameForIdentifier(int id) {
       return uniqueViewElementsClassNames.inverse().get(id);
     }
@@ -200,7 +200,7 @@ public class AccessibilityHierarchy {
    * AccessibilityHierarchy#builder}.
    */
   public static class Builder {
-    @Nullable protected AccessibilityHierarchyProto proto;
+    @NullableDecl protected AccessibilityHierarchyProto proto;
 
     public AccessibilityHierarchy build() {
       AccessibilityHierarchy result;

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/AccessibilityHierarchyAndroid.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/AccessibilityHierarchyAndroid.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Representation of a UI hierarchy for accessibility checking
@@ -278,9 +278,9 @@ public class AccessibilityHierarchyAndroid extends AccessibilityHierarchy implem
   private static WindowHierarchyElementAndroid buildWindowHierarchy(
       AccessibilityWindowInfo info,
       List<WindowHierarchyElementAndroid> elementList,
-      @Nullable WindowHierarchyElementAndroid parent,
+      @NullableDecl WindowHierarchyElementAndroid parent,
       BiMap<Long, AccessibilityNodeInfo> originMap,
-      @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
+      @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
     WindowHierarchyElementAndroid element =
         WindowHierarchyElementAndroid.newBuilder(elementList.size(), info, extraDataExtractor)
             .setParent(parent)
@@ -303,7 +303,7 @@ public class AccessibilityHierarchyAndroid extends AccessibilityHierarchy implem
   private static WindowHierarchyElementAndroid buildWindowHierarchy(
       Parcel fromParcel,
       List<WindowHierarchyElementAndroid> elementList,
-      @Nullable WindowHierarchyElementAndroid parent) {
+      @NullableDecl WindowHierarchyElementAndroid parent) {
     WindowHierarchyElementAndroid element =
         WindowHierarchyElementAndroid.newBuilder(elementList.size(), fromParcel)
             .setParent(parent)
@@ -467,7 +467,7 @@ public class AccessibilityHierarchyAndroid extends AccessibilityHierarchy implem
    *     AccessibilityNodeInfo} structures from which a {@link ViewHierarchyElementAndroid} was
    *     constructed, as populated by {@link AccessibilityHierarchyAndroid} constructors.
    */
-  private @Nullable ViewHierarchyElementAndroid findElementByNodeInfo(
+  private @NullableDecl ViewHierarchyElementAndroid findElementByNodeInfo(
       AccessibilityNodeInfo targetNode, BiMap<Long, AccessibilityNodeInfo> originMap) {
     Long viewId = originMap.inverse().get(targetNode);
     if (viewId == null) {
@@ -480,7 +480,7 @@ public class AccessibilityHierarchyAndroid extends AccessibilityHierarchy implem
    * Find the element corresponding to the View in value of {@code originMap} whose ID is {@code
    * targetViewId}, or {@code null} if no view is found with that ID.
    */
-  private @Nullable ViewHierarchyElementAndroid findElementByViewId(
+  private @NullableDecl ViewHierarchyElementAndroid findElementByViewId(
       int targetViewId, BiMap<Long, View> originMap) {
     for (Map.Entry<Long, View> matchingEntry : originMap.entrySet()) {
       if (matchingEntry.getValue().getId() == targetViewId) {
@@ -663,7 +663,7 @@ public class AccessibilityHierarchyAndroid extends AccessibilityHierarchy implem
       }
     }
 
-    private static @Nullable Class<?> getClassByName(
+    private static @NullableDecl Class<?> getClassByName(
         ViewHierarchyElementAndroid view, String className) {
 
       StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskReads();
@@ -688,12 +688,12 @@ public class AccessibilityHierarchyAndroid extends AccessibilityHierarchy implem
    * AccessibilityHierarchyAndroid#builder}.
    */
   public static class BuilderAndroid extends Builder {
-    private @Nullable View fromRootView;
-    private @Nullable List<AccessibilityWindowInfo> fromWindowList;
-    private @Nullable AccessibilityNodeInfo fromRootNode;
-    private @Nullable Context context;
-    private @Nullable BiMap<Long, AccessibilityNodeInfo> nodeInfoOriginMap;
-    private @Nullable BiMap<Long, View> viewOriginMap;
+    private @NullableDecl View fromRootView;
+    private @NullableDecl List<AccessibilityWindowInfo> fromWindowList;
+    private @NullableDecl AccessibilityNodeInfo fromRootNode;
+    private @NullableDecl Context context;
+    private @NullableDecl BiMap<Long, AccessibilityNodeInfo> nodeInfoOriginMap;
+    private @NullableDecl BiMap<Long, View> viewOriginMap;
     private boolean disposeInstances = false;
     private boolean obtainCharacterLocations = false;
 
@@ -754,7 +754,7 @@ public class AccessibilityHierarchyAndroid extends AccessibilityHierarchy implem
     }
 
     @VisibleForTesting
-    @Nullable
+    @NullableDecl
     AccessibilityNodeInfoExtraDataExtractor getAccessibilityNodeInfoExtraDataExtractor() {
       return obtainCharacterLocations ? new AccessibilityNodeInfoExtraDataExtractor() : null;
     }
@@ -797,7 +797,7 @@ public class AccessibilityHierarchyAndroid extends AccessibilityHierarchy implem
     private AccessibilityHierarchyAndroid buildHierarchyFromNodeInfo(
         AccessibilityNodeInfo fromRootNode,
         Context context,
-        @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
+        @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
       if (nodeInfoOriginMap == null) {
         // If we're not provided with a map to populate with originating structures, create one to
         // be used internally during hierarchy constructions
@@ -838,7 +838,7 @@ public class AccessibilityHierarchyAndroid extends AccessibilityHierarchy implem
     private AccessibilityHierarchyAndroid buildHierarchyFromWindowList(
         List<AccessibilityWindowInfo> fromWindowList,
         Context context,
-        @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
+        @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
       if (nodeInfoOriginMap == null) {
         // If we're not provided with a map to populate with originating structures, create one to
         // be used internally during hierarchy constructions

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/DisplayInfo.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/DisplayInfo.java
@@ -17,7 +17,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AccessibilityHierarchyProtos.DisplayInfoMetricsProto;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AccessibilityHierarchyProtos.DisplayInfoProto;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Representation of a {@link android.view.Display}
@@ -27,8 +27,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class DisplayInfo {
 
-  @Nullable private final Metrics metricsWithoutDecoration;
-  @Nullable private final Metrics realMetrics;
+  @NullableDecl private final Metrics metricsWithoutDecoration;
+  @NullableDecl private final Metrics realMetrics;
 
   DisplayInfo(DisplayInfoProto fromProto) {
     this.metricsWithoutDecoration = new Metrics(fromProto.getMetricsWithoutDecoration());
@@ -56,7 +56,7 @@ public class DisplayInfo {
    *     don't support resolution of real metrics.
    * @see android.view.Display#getRealMetrics(android.util.DisplayMetrics)
    */
-  @Nullable
+  @NullableDecl
   public Metrics getRealMetrics() {
     return realMetrics;
   }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/DisplayInfoAndroid.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/DisplayInfoAndroid.java
@@ -19,7 +19,7 @@ import android.util.DisplayMetrics;
 import android.view.Display;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AccessibilityHierarchyProtos.DisplayInfoMetricsProto;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AccessibilityHierarchyProtos.DisplayInfoProto;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Representation of a {@link Display}
@@ -30,7 +30,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class DisplayInfoAndroid extends DisplayInfo {
 
   private final MetricsAndroid metricsWithoutDecoration;
-  @Nullable private final MetricsAndroid realMetrics;
+  @NullableDecl private final MetricsAndroid realMetrics;
 
   /**
    * Derives an instance from a {@link Display}
@@ -83,7 +83,7 @@ public class DisplayInfoAndroid extends DisplayInfo {
    *     don't support resolution of real metrics.
    */
   @Override
-  public @Nullable MetricsAndroid getRealMetrics() {
+  public @NullableDecl MetricsAndroid getRealMetrics() {
     return realMetrics;
   }
 

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/ParcelUtils.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/ParcelUtils.java
@@ -10,7 +10,7 @@ import com.google.android.apps.common.testing.accessibility.framework.replacemen
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Utility class for writing to and reading from Parcels
@@ -36,7 +36,7 @@ final class ParcelUtils {
    * @param out a {@link Parcel} to which to write
    * @param val a value to represent
    */
-  public static void writeNullableInteger(Parcel out, @Nullable Integer val) {
+  public static void writeNullableInteger(Parcel out, @NullableDecl Integer val) {
     if (val == null) {
       out.writeInt(ABSENT);
     } else {
@@ -51,7 +51,7 @@ final class ParcelUtils {
    * @param in a {@link Parcel} from which to read
    * @return the represented value
    */
-  public static @Nullable Integer readNullableInteger(Parcel in) {
+  public static @NullableDecl Integer readNullableInteger(Parcel in) {
     int marker = in.readInt();
     if (marker == ABSENT) {
       return null;
@@ -70,7 +70,7 @@ final class ParcelUtils {
    * @param out a {@link Parcel} to which to write
    * @param val a value to represent
    */
-  public static void writeNullableLong(Parcel out, @Nullable Long val) {
+  public static void writeNullableLong(Parcel out, @NullableDecl Long val) {
     if (val == null) {
       out.writeInt(ABSENT);
     } else {
@@ -85,7 +85,7 @@ final class ParcelUtils {
    * @param in a {@link Parcel} from which to read
    * @return the represented value
    */
-  public static @Nullable Long readNullableLong(Parcel in) {
+  public static @NullableDecl Long readNullableLong(Parcel in) {
     int marker = in.readInt();
     if (marker == ABSENT) {
       return null;
@@ -104,7 +104,7 @@ final class ParcelUtils {
    * @param out a {@link Parcel} to which to write
    * @param val a value to represent
    */
-  public static void writeNullableFloat(Parcel out, @Nullable Float val) {
+  public static void writeNullableFloat(Parcel out, @NullableDecl Float val) {
     if (val == null) {
       out.writeInt(ABSENT);
     } else {
@@ -119,7 +119,7 @@ final class ParcelUtils {
    * @param in a {@link Parcel} from which to read
    * @return the represented value
    */
-  public static @Nullable Float readNullableFloat(Parcel in) {
+  public static @NullableDecl Float readNullableFloat(Parcel in) {
     int marker = in.readInt();
     if (marker == ABSENT) {
       return null;
@@ -138,7 +138,7 @@ final class ParcelUtils {
    * @param out a {@link Parcel} to which to write
    * @param val a value to represent
    */
-  public static void writeNullableString(Parcel out, @Nullable String val) {
+  public static void writeNullableString(Parcel out, @NullableDecl String val) {
     if (val == null) {
       out.writeInt(ABSENT);
     } else {
@@ -153,7 +153,7 @@ final class ParcelUtils {
    * @param in a {@link Parcel} from which to read
    * @return the represented value
    */
-  public static @Nullable String readNullableString(Parcel in) {
+  public static @NullableDecl String readNullableString(Parcel in) {
     int marker = in.readInt();
     if (marker == ABSENT) {
       return null;
@@ -172,7 +172,7 @@ final class ParcelUtils {
    * @param out a {@link Parcel} to which to write
    * @param val a value to represent
    */
-  public static void writeNullableBoolean(Parcel out, @Nullable Boolean val) {
+  public static void writeNullableBoolean(Parcel out, @NullableDecl Boolean val) {
     byte byteValue;
     if (val == null) {
       byteValue = -1;
@@ -188,7 +188,7 @@ final class ParcelUtils {
    * @param in a {@link Parcel} from which to read
    * @return the represented value
    */
-  public static @Nullable Boolean readNullableBoolean(Parcel in) {
+  public static @NullableDecl Boolean readNullableBoolean(Parcel in) {
     byte byteValue = in.readByte();
     if (byteValue == (byte) -1) {
       return null;

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/ViewHierarchyAction.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/ViewHierarchyAction.java
@@ -2,7 +2,7 @@ package com.google.android.apps.common.testing.accessibility.framework.uielement
 
 import com.google.android.apps.common.testing.accessibility.framework.replacements.TextUtils;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AccessibilityHierarchyProtos.ViewHierarchyActionProto;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Representation of {@code AccessibilityNodeInfo.AccessibilityAction} in a {@code View}.
@@ -12,9 +12,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class ViewHierarchyAction {
   private final int actionId;
-  private final @Nullable CharSequence actionLabel;
+  private final @NullableDecl CharSequence actionLabel;
 
-  protected ViewHierarchyAction(int actionId, @Nullable CharSequence actionLabel) {
+  protected ViewHierarchyAction(int actionId, @NullableDecl CharSequence actionLabel) {
     this.actionId = actionId;
     this.actionLabel = actionLabel;
   }
@@ -33,7 +33,7 @@ public class ViewHierarchyAction {
   }
 
   /** Returns the label of the corresponding action id. */
-  @Nullable
+  @NullableDecl
   CharSequence getActionLabel() {
     return actionLabel;
   }

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/ViewHierarchyActionAndroid.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/ViewHierarchyActionAndroid.java
@@ -3,7 +3,7 @@ package com.google.android.apps.common.testing.accessibility.framework.uielement
 import android.os.Parcel;
 import android.view.accessibility.AccessibilityNodeInfo.AccessibilityAction;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AccessibilityHierarchyProtos.ViewHierarchyActionProto;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Representation of {@code AccessibilityNodeInfo.AccessibilityAction} in a {@code View}.
@@ -13,7 +13,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class ViewHierarchyActionAndroid extends ViewHierarchyAction {
 
-  private ViewHierarchyActionAndroid(int actionId, @Nullable CharSequence actionLabel) {
+  private ViewHierarchyActionAndroid(int actionId, @NullableDecl CharSequence actionLabel) {
     super(actionId, actionLabel);
   }
 
@@ -41,7 +41,7 @@ public class ViewHierarchyActionAndroid extends ViewHierarchyAction {
   /** Builder for {@code ViewHierarchyElementAndroid} */
   static class Builder {
     private final int actionId;
-    private final @Nullable CharSequence actionLabel;
+    private final @NullableDecl CharSequence actionLabel;
 
     Builder(AccessibilityAction action) {
       this.actionId = action.getId();

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/ViewHierarchyElement.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/ViewHierarchyElement.java
@@ -30,8 +30,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.checkerframework.dataflow.qual.Pure;
 
 /**
@@ -46,51 +46,51 @@ import org.checkerframework.dataflow.qual.Pure;
  */
 public class ViewHierarchyElement {
   protected final int id;
-  protected final @Nullable Integer parentId;
+  protected final @NullableDecl Integer parentId;
 
   // Created lazily, because many views are leafs.
-  protected @MonotonicNonNull List<Integer> childIds;
+  protected @MonotonicNonNullDecl List<Integer> childIds;
 
   // This field is set to a non-null value after construction.
-  private @MonotonicNonNull WindowHierarchyElement windowElement;
+  private @MonotonicNonNullDecl WindowHierarchyElement windowElement;
 
-  protected final @Nullable CharSequence packageName;
-  protected final @Nullable CharSequence className;
-  protected final @Nullable CharSequence accessibilityClassName;
-  protected final @Nullable String resourceName;
-  protected final @Nullable SpannableString contentDescription;
-  protected final @Nullable SpannableString text;
+  protected final @NullableDecl CharSequence packageName;
+  protected final @NullableDecl CharSequence className;
+  protected final @NullableDecl CharSequence accessibilityClassName;
+  protected final @NullableDecl String resourceName;
+  protected final @NullableDecl SpannableString contentDescription;
+  protected final @NullableDecl SpannableString text;
   protected final boolean importantForAccessibility;
-  protected final @Nullable Boolean visibleToUser;
+  protected final @NullableDecl Boolean visibleToUser;
   protected final boolean clickable;
   protected final boolean longClickable;
   protected final boolean focusable;
-  protected final @Nullable Boolean editable;
-  protected final @Nullable Boolean scrollable;
-  protected final @Nullable Boolean canScrollForward;
-  protected final @Nullable Boolean canScrollBackward;
-  protected final @Nullable Boolean checkable;
-  protected final @Nullable Boolean checked;
-  protected final @Nullable Boolean hasTouchDelegate;
-  protected final @Nullable Rect boundsInScreen;
-  protected final @Nullable Integer nonclippedHeight;
-  protected final @Nullable Integer nonclippedWidth;
-  protected final @Nullable Float textSize;
-  protected final @Nullable Integer textColor;
-  protected final @Nullable Integer backgroundDrawableColor;
-  protected final @Nullable Integer typefaceStyle;
+  protected final @NullableDecl Boolean editable;
+  protected final @NullableDecl Boolean scrollable;
+  protected final @NullableDecl Boolean canScrollForward;
+  protected final @NullableDecl Boolean canScrollBackward;
+  protected final @NullableDecl Boolean checkable;
+  protected final @NullableDecl Boolean checked;
+  protected final @NullableDecl Boolean hasTouchDelegate;
+  protected final @NullableDecl Rect boundsInScreen;
+  protected final @NullableDecl Integer nonclippedHeight;
+  protected final @NullableDecl Integer nonclippedWidth;
+  protected final @NullableDecl Float textSize;
+  protected final @NullableDecl Integer textColor;
+  protected final @NullableDecl Integer backgroundDrawableColor;
+  protected final @NullableDecl Integer typefaceStyle;
   protected final boolean enabled;
-  protected final @Nullable Integer drawingOrder;
+  protected final @NullableDecl Integer drawingOrder;
   protected final ImmutableList<ViewHierarchyAction> actionList;
-  protected final @Nullable LayoutParams layoutParams;
-  protected final @Nullable SpannableString hintText; // only for TextView
-  protected final @Nullable Integer hintTextColor; // only for TextView
+  protected final @NullableDecl LayoutParams layoutParams;
+  protected final @NullableDecl SpannableString hintText; // only for TextView
+  protected final @NullableDecl Integer hintTextColor; // only for TextView
   protected final List<Rect> textCharacterLocations;
 
   // Populated only after a hierarchy is constructed
-  protected @Nullable Long labeledById;
-  protected @Nullable Long accessibilityTraversalBeforeId;
-  protected @Nullable Long accessibilityTraversalAfterId;
+  protected @NullableDecl Long labeledById;
+  protected @NullableDecl Long accessibilityTraversalBeforeId;
+  protected @NullableDecl Long accessibilityTraversalAfterId;
   protected List<Rect> touchDelegateBounds;
 
   // A list of identifiers that represents all the superclasses of the corresponding view element.
@@ -98,44 +98,44 @@ public class ViewHierarchyElement {
 
   protected ViewHierarchyElement(
       int id,
-      @Nullable Integer parentId,
+      @NullableDecl Integer parentId,
       List<Integer> childIds,
-      @Nullable CharSequence packageName,
-      @Nullable CharSequence className,
-      @Nullable CharSequence accessibilityClassName,
-      @Nullable String resourceName,
-      @Nullable SpannableString contentDescription,
-      @Nullable SpannableString text,
+      @NullableDecl CharSequence packageName,
+      @NullableDecl CharSequence className,
+      @NullableDecl CharSequence accessibilityClassName,
+      @NullableDecl String resourceName,
+      @NullableDecl SpannableString contentDescription,
+      @NullableDecl SpannableString text,
       boolean importantForAccessibility,
-      @Nullable Boolean visibleToUser,
+      @NullableDecl Boolean visibleToUser,
       boolean clickable,
       boolean longClickable,
       boolean focusable,
-      @Nullable Boolean editable,
-      @Nullable Boolean scrollable,
-      @Nullable Boolean canScrollForward,
-      @Nullable Boolean canScrollBackward,
-      @Nullable Boolean checkable,
-      @Nullable Boolean checked,
-      @Nullable Boolean hasTouchDelegate,
+      @NullableDecl Boolean editable,
+      @NullableDecl Boolean scrollable,
+      @NullableDecl Boolean canScrollForward,
+      @NullableDecl Boolean canScrollBackward,
+      @NullableDecl Boolean checkable,
+      @NullableDecl Boolean checked,
+      @NullableDecl Boolean hasTouchDelegate,
       List<Rect> touchDelegateBounds,
-      @Nullable Rect boundsInScreen,
-      @Nullable Integer nonclippedHeight,
-      @Nullable Integer nonclippedWidth,
-      @Nullable Float textSize,
-      @Nullable Integer textColor,
-      @Nullable Integer backgroundDrawableColor,
-      @Nullable Integer typefaceStyle,
+      @NullableDecl Rect boundsInScreen,
+      @NullableDecl Integer nonclippedHeight,
+      @NullableDecl Integer nonclippedWidth,
+      @NullableDecl Float textSize,
+      @NullableDecl Integer textColor,
+      @NullableDecl Integer backgroundDrawableColor,
+      @NullableDecl Integer typefaceStyle,
       boolean enabled,
-      @Nullable Long labeledById,
-      @Nullable Long accessibilityTraversalBeforeId,
-      @Nullable Long accessibilityTraversalAfterId,
-      @Nullable Integer drawingOrder,
+      @NullableDecl Long labeledById,
+      @NullableDecl Long accessibilityTraversalBeforeId,
+      @NullableDecl Long accessibilityTraversalAfterId,
+      @NullableDecl Integer drawingOrder,
       List<Integer> superclassViews,
       List<? extends ViewHierarchyAction> actionList,
-      @Nullable LayoutParams layoutParams,
-      @Nullable SpannableString hintText,
-      @Nullable Integer hintTextColor,
+      @NullableDecl LayoutParams layoutParams,
+      @NullableDecl SpannableString hintText,
+      @NullableDecl Integer hintTextColor,
       List<Rect> textCharacterLocations) {
     this.id = id;
     this.parentId = parentId;
@@ -285,7 +285,7 @@ public class ViewHierarchyElement {
    * @see android.view.View#getParent()
    */
   @Pure
-  public @Nullable ViewHierarchyElement getParentView() {
+  public @NullableDecl ViewHierarchyElement getParentView() {
     Integer parentIdtmp = parentId;
     return (parentIdtmp != null) ? getWindow().getViewById(parentIdtmp) : null;
   }
@@ -333,8 +333,8 @@ public class ViewHierarchyElement {
    */
   public WindowHierarchyElement getWindow() {
 
-    // The type is explicit because the @MonotonicNonNull field is not read as @Nullable.
-    return Preconditions.<@Nullable WindowHierarchyElement>checkNotNull(windowElement);
+    // The type is explicit because the @MonotonicNonNull field is not read as @NullableDecl.
+    return Preconditions.<WindowHierarchyElement>checkNotNull(windowElement);
   }
 
   /**
@@ -343,7 +343,7 @@ public class ViewHierarchyElement {
    * @see android.view.accessibility.AccessibilityNodeInfo#getPackageName()
    * @see android.content.Context#getPackageName()
    */
-  public @Nullable CharSequence getPackageName() {
+  public @NullableDecl CharSequence getPackageName() {
     return packageName;
   }
 
@@ -352,7 +352,7 @@ public class ViewHierarchyElement {
    * @see android.view.accessibility.AccessibilityNodeInfo#getPackageName()
    * @see android.view.View#getClass()
    */
-  public @Nullable CharSequence getClassName() {
+  public @NullableDecl CharSequence getClassName() {
     return className;
   }
 
@@ -363,8 +363,8 @@ public class ViewHierarchyElement {
    * @see android.view.View#getId()
    * @see android.content.res.Resources#getResourceName(int)
    */
-  @Pure
-  public @Nullable String getResourceName() {
+  //@Pure
+  public @NullableDecl String getResourceName() {
     return resourceName;
   }
 
@@ -406,7 +406,7 @@ public class ViewHierarchyElement {
    * @see android.view.accessibility.AccessibilityNodeInfo#getContentDescription()
    * @see android.view.View#getContentDescription()
    */
-  public @Nullable SpannableString getContentDescription() {
+  public @NullableDecl SpannableString getContentDescription() {
     return contentDescription;
   }
 
@@ -426,7 +426,7 @@ public class ViewHierarchyElement {
    * @see android.widget.TextView#getText()
    * @see android.widget.TextView#getHint()
    */
-  public @Nullable SpannableString getText() {
+  public @NullableDecl SpannableString getText() {
     return text;
   }
 
@@ -435,7 +435,7 @@ public class ViewHierarchyElement {
    *     not, or {@code null} if this cannot be determined.
    * @see android.view.accessibility.AccessibilityNodeInfo#isVisibleToUser()
    */
-  public @Nullable Boolean isVisibleToUser() {
+  public @NullableDecl Boolean isVisibleToUser() {
     return visibleToUser;
   }
 
@@ -473,7 +473,7 @@ public class ViewHierarchyElement {
    * @return {@link Boolean#TRUE} if the element is editable, {@link Boolean#FALSE} if not, or
    *     {@code null} if this cannot be determined.
    */
-  public @Nullable Boolean isEditable() {
+  public @NullableDecl Boolean isEditable() {
     return editable;
   }
 
@@ -485,7 +485,7 @@ public class ViewHierarchyElement {
    *     determine if an element is actually scrollable based on contents use {@link
    *     #canScrollForward} or {@link #canScrollBackward}.
    */
-  public @Nullable Boolean isScrollable() {
+  public @NullableDecl Boolean isScrollable() {
     return scrollable;
   }
 
@@ -494,7 +494,7 @@ public class ViewHierarchyElement {
    *         meaning either vertically downward or horizontally to the right (in left-to-right
    *         locales), {@link Boolean#FALSE} if not, or {@code null if this cannot be determined.
    */
-  public @Nullable Boolean canScrollForward() {
+  public @NullableDecl Boolean canScrollForward() {
     return canScrollForward;
   }
 
@@ -504,7 +504,7 @@ public class ViewHierarchyElement {
    *         left-to-right locales), {@link Boolean#FALSE} if not, or {@code null if this cannot be
    *         determined.
    */
-  public @Nullable Boolean canScrollBackward() {
+  public @NullableDecl Boolean canScrollBackward() {
     return canScrollBackward;
   }
 
@@ -512,7 +512,7 @@ public class ViewHierarchyElement {
    * @return {@link Boolean#TRUE} if the element is checkable, {@link Boolean#FALSE} if not, or
    *     {@code null} if this cannot be determined.
    */
-  public @Nullable Boolean isCheckable() {
+  public @NullableDecl Boolean isCheckable() {
     return checkable;
   }
 
@@ -520,7 +520,7 @@ public class ViewHierarchyElement {
    * @return {@link Boolean#TRUE} if the element is checked, {@link Boolean#FALSE} if not, or {@code
    *     null} if this cannot be determined.
    */
-  public @Nullable Boolean isChecked() {
+  public @NullableDecl Boolean isChecked() {
     return checked;
   }
 
@@ -529,7 +529,7 @@ public class ViewHierarchyElement {
    * Boolean#FALSE} if not, or {@code null} if this cannot be determined. This indicates only that
    * this element may be responsible for delegating its touches to another element.
    */
-  public @Nullable Boolean hasTouchDelegate() {
+  public @NullableDecl Boolean hasTouchDelegate() {
     return hasTouchDelegate;
   }
 
@@ -571,7 +571,7 @@ public class ViewHierarchyElement {
    *     applied by parent elements.
    * @see android.view.View#getHeight()
    */
-  public @Nullable Integer getNonclippedHeight() {
+  public @NullableDecl Integer getNonclippedHeight() {
     return nonclippedHeight;
   }
 
@@ -580,7 +580,7 @@ public class ViewHierarchyElement {
    *     applied by parent elements.
    * @see android.view.View#getWidth()
    */
-  public @Nullable Integer getNonclippedWidth() {
+  public @NullableDecl Integer getNonclippedWidth() {
     return nonclippedWidth;
   }
 
@@ -589,7 +589,7 @@ public class ViewHierarchyElement {
    *     this cannot be determined
    * @see android.widget.TextView#getTextSize()
    */
-  public @Nullable Float getTextSize() {
+  public @NullableDecl Float getTextSize() {
     return textSize;
   }
 
@@ -598,7 +598,7 @@ public class ViewHierarchyElement {
    *     determined
    * @see android.widget.TextView#getCurrentTextColor()
    */
-  public @Nullable Integer getTextColor() {
+  public @NullableDecl Integer getTextColor() {
     return textColor;
   }
 
@@ -608,7 +608,7 @@ public class ViewHierarchyElement {
    * @see android.view.View#getBackground()
    * @see android.graphics.drawable.ColorDrawable#getColor()
    */
-  public @Nullable Integer getBackgroundDrawableColor() {
+  public @NullableDecl Integer getBackgroundDrawableColor() {
     return backgroundDrawableColor;
   }
 
@@ -624,7 +624,7 @@ public class ViewHierarchyElement {
    * @see android.graphics.Typeface#BOLD_ITALIC
    */
   @Pure
-  public @Nullable Integer getTypefaceStyle() {
+  public @NullableDecl Integer getTypefaceStyle() {
     return typefaceStyle;
   }
 
@@ -644,7 +644,7 @@ public class ViewHierarchyElement {
    *     <p>NOTE: Unavailable for instances originally created from a {@link android.view.View}
    * @see android.view.accessibility.AccessibilityNodeInfo#getClassName()
    */
-  public @Nullable CharSequence getAccessibilityClassName() {
+  public @NullableDecl CharSequence getAccessibilityClassName() {
     return accessibilityClassName;
   }
 
@@ -657,7 +657,7 @@ public class ViewHierarchyElement {
    * @see android.view.View#getLabelFor()
    */
   @Pure
-  public @Nullable ViewHierarchyElement getLabeledBy() {
+  public @NullableDecl ViewHierarchyElement getLabeledBy() {
     return getViewHierarchyElementById(labeledById);
   }
 
@@ -666,7 +666,7 @@ public class ViewHierarchyElement {
    * @see android.view.accessibility.AccessibilityNodeInfo#getTraversalBefore()
    * @see android.view.View#getAccessibilityTraversalBefore()
    */
-  public @Nullable ViewHierarchyElement getAccessibilityTraversalBefore() {
+  public @NullableDecl ViewHierarchyElement getAccessibilityTraversalBefore() {
     return getViewHierarchyElementById(accessibilityTraversalBeforeId);
   }
 
@@ -675,7 +675,7 @@ public class ViewHierarchyElement {
    * @see android.view.accessibility.AccessibilityNodeInfo#getTraversalAfter()
    * @see android.view.View#getAccessibilityTraversalAfter()
    */
-  public @Nullable ViewHierarchyElement getAccessibilityTraversalAfter() {
+  public @NullableDecl ViewHierarchyElement getAccessibilityTraversalAfter() {
     return getViewHierarchyElementById(accessibilityTraversalAfterId);
   }
 
@@ -685,7 +685,7 @@ public class ViewHierarchyElement {
    *
    * @see android.view.accessibility.AccessibilityNodeInfo#getDrawingOrder()
    */
-  public @Nullable Integer getDrawingOrder() {
+  public @NullableDecl Integer getDrawingOrder() {
     return drawingOrder;
   }
 
@@ -695,7 +695,7 @@ public class ViewHierarchyElement {
    *
    * @see android.view.ViewGroup.LayoutParams
    */
-  public @Nullable LayoutParams getLayoutParams() {
+  public @NullableDecl LayoutParams getLayoutParams() {
     return layoutParams;
   }
 
@@ -705,7 +705,7 @@ public class ViewHierarchyElement {
    *
    * @see android.widget.TextView#getHint()
    */
-  public @Nullable SpannableString getHintText() {
+  public @NullableDecl SpannableString getHintText() {
     return hintText;
   }
 
@@ -715,7 +715,7 @@ public class ViewHierarchyElement {
    *
    * @see android.widget.TextView#getCurrentHintTextColor()
    */
-  public @Nullable Integer getHintTextColor() {
+  public @NullableDecl Integer getHintTextColor() {
     return hintTextColor;
   }
 
@@ -768,7 +768,7 @@ public class ViewHierarchyElement {
   }
 
   @Override
-  public boolean equals(@Nullable Object object) {
+  public boolean equals(@NullableDecl Object object) {
     if (object == this) {
       return true;
     }
@@ -972,7 +972,7 @@ public class ViewHierarchyElement {
     touchDelegateBounds.add(bounds);
   }
 
-  private @Nullable ViewHierarchyElement getViewHierarchyElementById(@Nullable Long id) {
+  private @NullableDecl ViewHierarchyElement getViewHierarchyElementById(@NullableDecl Long id) {
     return (id != null) ? getWindow().getAccessibilityHierarchy().getViewById(id) : null;
   }
 
@@ -1018,7 +1018,7 @@ public class ViewHierarchyElement {
   }
 
   private static boolean condensedUniqueIdEquals(
-      @Nullable ViewHierarchyElement ve1, @Nullable ViewHierarchyElement ve2) {
+      @NullableDecl ViewHierarchyElement ve1, @NullableDecl ViewHierarchyElement ve2) {
     return (ve1 == null)
         ? (ve2 == null)
         : ((ve2 != null) && (ve1.getCondensedUniqueId() == ve2.getCondensedUniqueId()));

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/ViewHierarchyElementAndroid.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/ViewHierarchyElementAndroid.java
@@ -32,6 +32,7 @@ import com.google.android.apps.common.testing.accessibility.framework.replacemen
 import com.google.android.apps.common.testing.accessibility.framework.replacements.SpannableStringAndroid;
 import com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AccessibilityHierarchyProtos.ViewHierarchyElementProto;
 import com.google.android.material.button.MaterialButton;
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -39,9 +40,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.dataflow.qual.Pure;
+import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
+import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullType;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+//import org.checkerframework.dataflow.compatqual.Pure;
 
 /**
  * Representation of a {@link View} hierarchy for accessibility checking
@@ -66,48 +68,49 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
   private static final boolean AT_11 = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB);
 
   // This field is set to a non-null value after construction.
-  private @MonotonicNonNull WindowHierarchyElementAndroid windowElement;
+  private @MonotonicNonNullDecl
+  WindowHierarchyElementAndroid windowElement;
 
   private ViewHierarchyElementAndroid(
       int id,
-      @Nullable Integer parentId,
+      @NullableDecl Integer parentId,
       List<Integer> childIds,
-      @Nullable CharSequence packageName,
-      @Nullable CharSequence className,
-      @Nullable CharSequence accessibilityClassName,
-      @Nullable String resourceName,
-      @Nullable SpannableString contentDescription,
-      @Nullable SpannableString text,
+      @NullableDecl CharSequence packageName,
+      @NullableDecl CharSequence className,
+      @NullableDecl CharSequence accessibilityClassName,
+      @NullableDecl String resourceName,
+      @NullableDecl SpannableString contentDescription,
+      @NullableDecl SpannableString text,
       boolean importantForAccessibility,
-      @Nullable Boolean visibleToUser,
+      @NullableDecl Boolean visibleToUser,
       boolean clickable,
       boolean longClickable,
       boolean focusable,
-      @Nullable Boolean editable,
-      @Nullable Boolean scrollable,
-      @Nullable Boolean canScrollForward,
-      @Nullable Boolean canScrollBackward,
-      @Nullable Boolean checkable,
-      @Nullable Boolean checked,
-      @Nullable Boolean hasTouchDelegate,
+      @NullableDecl Boolean editable,
+      @NullableDecl Boolean scrollable,
+      @NullableDecl Boolean canScrollForward,
+      @NullableDecl Boolean canScrollBackward,
+      @NullableDecl Boolean checkable,
+      @NullableDecl Boolean checked,
+      @NullableDecl Boolean hasTouchDelegate,
       List<Rect> touchDelegateBounds,
-      @Nullable Rect boundsInScreen,
-      @Nullable Integer nonclippedHeight,
-      @Nullable Integer nonclippedWidth,
-      @Nullable Float textSize,
-      @Nullable Integer textColor,
-      @Nullable Integer backgroundDrawableColor,
-      @Nullable Integer typefaceStyle,
+      @NullableDecl Rect boundsInScreen,
+      @NullableDecl Integer nonclippedHeight,
+      @NullableDecl Integer nonclippedWidth,
+      @NullableDecl Float textSize,
+      @NullableDecl Integer textColor,
+      @NullableDecl Integer backgroundDrawableColor,
+      @NullableDecl Integer typefaceStyle,
       boolean enabled,
-      @Nullable Long labeledById,
-      @Nullable Long accessibilityTraversalBeforeId,
-      @Nullable Long accessibilityTraversalAfterId,
-      @Nullable Integer drawingOrder,
+      @NullableDecl Long labeledById,
+      @NullableDecl Long accessibilityTraversalBeforeId,
+      @NullableDecl Long accessibilityTraversalAfterId,
+      @NullableDecl Integer drawingOrder,
       List<Integer> superclassViews,
       List<ViewHierarchyActionAndroid> actionList,
-      @Nullable LayoutParams layoutParams,
-      @Nullable SpannableString hintText,
-      @Nullable Integer hintTextColor,
+      @NullableDecl LayoutParams layoutParams,
+      @NullableDecl SpannableString hintText,
+      @NullableDecl Integer hintTextColor,
       List<Rect> textCharacterLocations) {
     super(
         id,
@@ -158,9 +161,9 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
    * @see AccessibilityNodeInfo#getParent()
    * @see View#getParent()
    */
-  @Pure
+  //@Pure
   @Override
-  public @Nullable ViewHierarchyElementAndroid getParentView() {
+  public @NullableDecl ViewHierarchyElementAndroid getParentView() {
     Integer parentIdTmp = parentId;
     return (parentIdTmp != null) ? getWindow().getViewById(parentIdTmp) : null;
   }
@@ -200,8 +203,8 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
   @Override
   public WindowHierarchyElementAndroid getWindow() {
 
-    // The type is explicit because the @MonotonicNonNull field is not read as @Nullable.
-    return Preconditions.<@Nullable WindowHierarchyElementAndroid>checkNotNull(windowElement);
+    // The type is explicit because the @MonotonicNonNull field is not read as @NullableDecl.
+    return Preconditions.<WindowHierarchyElementAndroid>checkNotNull(windowElement);
   }
 
   /**
@@ -211,9 +214,9 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
    * @see AccessibilityNodeInfo#getLabelFor()
    * @see View#getLabelFor()
    */
-  @Pure
+  //@Pure
   @Override
-  public @Nullable ViewHierarchyElementAndroid getLabeledBy() {
+  public @NullableDecl ViewHierarchyElementAndroid getLabeledBy() {
     return getViewHierarchyElementById(labeledById);
   }
 
@@ -223,7 +226,7 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
    * @see View#getAccessibilityTraversalBefore()
    */
   @Override
-  public @Nullable ViewHierarchyElementAndroid getAccessibilityTraversalBefore() {
+  public @NullableDecl ViewHierarchyElementAndroid getAccessibilityTraversalBefore() {
     return getViewHierarchyElementById(accessibilityTraversalBeforeId);
   }
 
@@ -233,7 +236,7 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
    * @see View#getAccessibilityTraversalAfter()
    */
   @Override
-  public @Nullable ViewHierarchyElementAndroid getAccessibilityTraversalAfter() {
+  public @NullableDecl ViewHierarchyElementAndroid getAccessibilityTraversalAfter() {
     return getViewHierarchyElementById(accessibilityTraversalAfterId);
   }
 
@@ -379,12 +382,12 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
     accessibilityTraversalAfterId = element.getCondensedUniqueId();
   }
 
-  private @Nullable ViewHierarchyElementAndroid getViewHierarchyElementById(@Nullable Long id) {
+  private @NullableDecl ViewHierarchyElementAndroid getViewHierarchyElementById(@NullableDecl Long id) {
     return (id != null) ? getWindow().getAccessibilityHierarchy().getViewById(id) : null;
   }
 
   /** Returns a new builder that can build a ViewHierarchyElementAndroid from a View. */
-  static Builder newBuilder(int id, @Nullable ViewHierarchyElementAndroid parent, View fromView) {
+  static Builder newBuilder(int id, @NullableDecl ViewHierarchyElementAndroid parent, View fromView) {
     return new Builder(id, parent, fromView);
   }
 
@@ -394,9 +397,9 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
    */
   static Builder newBuilder(
       int id,
-      @Nullable ViewHierarchyElementAndroid parent,
+      @NullableDecl ViewHierarchyElementAndroid parent,
       AccessibilityNodeInfo fromInfo,
-      @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
+      @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
     return new Builder(id, parent, fromInfo, extraDataExtractor);
   }
 
@@ -406,7 +409,7 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
   }
 
   /** Returns a new builder that can build a ViewHierarchyElementAndroid from a Parcel. */
-  static Builder newBuilder(int id, @Nullable ViewHierarchyElementAndroid parent, Parcel in) {
+  static Builder newBuilder(int id, @NullableDecl ViewHierarchyElementAndroid parent, Parcel in) {
     return new Builder(id, parent, in);
   }
 
@@ -416,51 +419,51 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
    */
   public static class Builder {
     private final int id;
-    private final @Nullable Integer parentId;
+    private final @NullableDecl Integer parentId;
     private List<Integer> childIds = new ArrayList<>();
-    private final @Nullable CharSequence packageName;
-    private final @Nullable CharSequence className;
-    private final @Nullable CharSequence accessibilityClassName;
-    private final @Nullable String resourceName;
-    private final @Nullable SpannableString contentDescription;
-    private final @Nullable SpannableString text;
+    private final @NullableDecl CharSequence packageName;
+    private final @NullableDecl CharSequence className;
+    private final @NullableDecl CharSequence accessibilityClassName;
+    private final @NullableDecl String resourceName;
+    private final @NullableDecl SpannableString contentDescription;
+    private final @NullableDecl SpannableString text;
     private final boolean importantForAccessibility;
-    private final @Nullable Boolean visibleToUser;
+    private final @NullableDecl Boolean visibleToUser;
     private final boolean clickable;
     private final boolean longClickable;
     private final boolean focusable;
-    private final @Nullable Boolean editable;
-    private final @Nullable Boolean scrollable;
-    private final @Nullable Boolean canScrollForward;
-    private final @Nullable Boolean canScrollBackward;
-    private final @Nullable Boolean checkable;
-    private final @Nullable Boolean checked;
-    private final @Nullable Boolean hasTouchDelegate;
+    private final @NullableDecl Boolean editable;
+    private final @NullableDecl Boolean scrollable;
+    private final @NullableDecl Boolean canScrollForward;
+    private final @NullableDecl Boolean canScrollBackward;
+    private final @NullableDecl Boolean checkable;
+    private final @NullableDecl Boolean checked;
+    private final @NullableDecl Boolean hasTouchDelegate;
     private final List<Rect> touchDelegateBounds;
-    private final @Nullable Rect boundsInScreen;
-    private final @Nullable Integer nonclippedHeight;
-    private final @Nullable Integer nonclippedWidth;
-    private final @Nullable Float textSize;
-    private final @Nullable Integer textColor;
-    private final @Nullable Integer backgroundDrawableColor;
-    private final @Nullable Integer typefaceStyle;
+    private final @NullableDecl Rect boundsInScreen;
+    private final @NullableDecl Integer nonclippedHeight;
+    private final @NullableDecl Integer nonclippedWidth;
+    private final @NullableDecl Float textSize;
+    private final @NullableDecl Integer textColor;
+    private final @NullableDecl Integer backgroundDrawableColor;
+    private final @NullableDecl Integer typefaceStyle;
     private final boolean enabled;
-    private @Nullable Long labeledById;
-    private @Nullable Long accessibilityTraversalBeforeId;
-    private @Nullable Long accessibilityTraversalAfterId;
+    private @NullableDecl Long labeledById;
+    private @NullableDecl Long accessibilityTraversalBeforeId;
+    private @NullableDecl Long accessibilityTraversalAfterId;
     private final List<Integer> superclassViews = new ArrayList<>();
-    private final @Nullable Integer drawingOrder;
+    private final @NullableDecl Integer drawingOrder;
     private ImmutableList<ViewHierarchyActionAndroid> actionList;
-    private final @Nullable LayoutParams layoutParams;
-    private final @Nullable SpannableString hintText;
-    private final @Nullable Integer hintTextColor;
+    private final @NullableDecl LayoutParams layoutParams;
+    private final @NullableDecl SpannableString hintText;
+    private final @NullableDecl Integer hintTextColor;
     private final List<Rect> textCharacterLocations;
 
     Builder(
         int id,
-        @Nullable ViewHierarchyElementAndroid parent,
+        @NullableDecl ViewHierarchyElementAndroid parent,
         AccessibilityNodeInfo fromInfo,
-        @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
+        @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
       // Bookkeeping
       this.id = id;
       this.parentId = (parent != null) ? parent.getId() : null;
@@ -479,7 +482,13 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
         actionBuilder.addAll(
             Lists.transform(
                 fromInfo.getActionList(),
-                action -> ViewHierarchyActionAndroid.newBuilder(action).build()));
+                new Function<AccessibilityAction, ViewHierarchyActionAndroid>() {
+                  @NullableDecl
+                  @Override
+                  public ViewHierarchyActionAndroid apply(@NullableDecl AccessibilityAction action) {
+                    return ViewHierarchyActionAndroid.newBuilder(action).build();
+                  }
+                }));
         this.actionList = actionBuilder.build();
       }
 
@@ -535,10 +544,10 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
       this.textCharacterLocations =
           (AT_26 && (extraDataExtractor != null))
               ? extraDataExtractor.getTextCharacterLocations(fromInfo)
-              : ImmutableList.of();
+              : ImmutableList.<Rect>of();
     }
 
-    Builder(int id, @Nullable ViewHierarchyElementAndroid parent, View fromView) {
+    Builder(int id, @NullableDecl ViewHierarchyElementAndroid parent, View fromView) {
       // Bookkeeping
       this.id = id;
       this.parentId = (parent != null) ? parent.getId() : null;
@@ -610,7 +619,7 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
       this.textCharacterLocations = ImmutableList.of();
     }
 
-    Builder(int id, @Nullable ViewHierarchyElementAndroid parent, Parcel in) {
+    Builder(int id, @NullableDecl ViewHierarchyElementAndroid parent, Parcel in) {
       // Bookkeeping
       this.id = id;
       this.parentId = (parent != null) ? parent.getId() : null;
@@ -804,7 +813,7 @@ public class ViewHierarchyElementAndroid extends ViewHierarchyElement {
      * <p>There may be subtle differences between the bounds from a View instance compared to that
      * of its AccessibilityNodeInfo. The latter uses View#getBoundsOnScreen method.
      */
-    private static @Nullable Rect getBoundsInScreen(View fromView) {
+    private static @NullableDecl Rect getBoundsInScreen(View fromView) {
       android.graphics.Rect tempRect = new android.graphics.Rect();
       if (!fromView.getGlobalVisibleRect(tempRect)) {
         return null;

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/WindowHierarchyElement.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/WindowHierarchyElement.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Representation of a {@link android.view.Window} hierarchy for accessibility checking
@@ -46,31 +46,31 @@ public class WindowHierarchyElement {
   private final List<ViewHierarchyElement> viewHierarchyElements;
 
   protected final int id;
-  protected final @Nullable Integer parentId;
+  protected final @NullableDecl Integer parentId;
   protected final List<Integer> childIds = new ArrayList<>();
 
   // This field is set to a non-null value after construction.
-  private @MonotonicNonNull AccessibilityHierarchy accessibilityHierarchy;
+  private @MonotonicNonNullDecl AccessibilityHierarchy accessibilityHierarchy;
 
-  protected final @Nullable Integer windowId;
-  protected final @Nullable Integer layer;
-  protected final @Nullable Integer type;
-  protected final @Nullable Boolean focused;
-  protected final @Nullable Boolean accessibilityFocused;
-  protected final @Nullable Boolean active;
-  protected final @Nullable Rect boundsInScreen;
+  protected final @NullableDecl Integer windowId;
+  protected final @NullableDecl Integer layer;
+  protected final @NullableDecl Integer type;
+  protected final @NullableDecl Boolean focused;
+  protected final @NullableDecl Boolean accessibilityFocused;
+  protected final @NullableDecl Boolean active;
+  protected final @NullableDecl Rect boundsInScreen;
 
   protected WindowHierarchyElement(
       int id,
-      @Nullable Integer parentId,
+      @NullableDecl Integer parentId,
       List<Integer> childIds,
-      @Nullable Integer windowId,
-      @Nullable Integer layer,
-      @Nullable Integer type,
-      @Nullable Boolean focused,
-      @Nullable Boolean accessibilityFocused,
-      @Nullable Boolean active,
-      @Nullable Rect boundsInScreen) {
+      @NullableDecl Integer windowId,
+      @NullableDecl Integer layer,
+      @NullableDecl Integer type,
+      @NullableDecl Boolean focused,
+      @NullableDecl Boolean accessibilityFocused,
+      @NullableDecl Boolean active,
+      @NullableDecl Rect boundsInScreen) {
     this.viewHierarchyElements = new ArrayList<>();
     this.id = id;
     this.parentId = parentId;
@@ -121,7 +121,7 @@ public class WindowHierarchyElement {
    *     does not have a root view.
    * @see android.view.accessibility.AccessibilityWindowInfo#getRoot()
    */
-  public @Nullable ViewHierarchyElement getRootView() {
+  public @NullableDecl ViewHierarchyElement getRootView() {
     if (viewHierarchyElements.isEmpty()) {
       return null;
     }
@@ -145,7 +145,7 @@ public class WindowHierarchyElement {
    *     window is a root window.
    * @see android.view.accessibility.AccessibilityWindowInfo#getParent()
    */
-  public @Nullable WindowHierarchyElement getParentWindow() {
+  public @NullableDecl WindowHierarchyElement getParentWindow() {
     Integer parentIdTmp = parentId;
     return (parentIdTmp != null) ? getAccessibilityHierarchy().getWindowById(parentIdTmp) : null;
   }
@@ -190,8 +190,8 @@ public class WindowHierarchyElement {
    */
   public AccessibilityHierarchy getAccessibilityHierarchy() {
 
-    // The type is explicit because the @MonotonicNonNull field is not read as @Nullable.
-    return Preconditions.<@Nullable AccessibilityHierarchy>checkNotNull(accessibilityHierarchy);
+    // The type is explicit because the @MonotonicNonNull field is not read as @NullableDecl.
+    return Preconditions.<AccessibilityHierarchy>checkNotNull(accessibilityHierarchy);
   }
 
   /**
@@ -200,7 +200,7 @@ public class WindowHierarchyElement {
    * @see android.view.accessibility.AccessibilityWindowInfo#getId()
    * @see android.view.accessibility.AccessibilityNodeInfo#getWindowId()
    */
-  public @Nullable Integer getWindowId() {
+  public @NullableDecl Integer getWindowId() {
     return windowId;
   }
 
@@ -209,7 +209,7 @@ public class WindowHierarchyElement {
    *     determined
    * @see android.view.accessibility.AccessibilityWindowInfo#getLayer()
    */
-  public @Nullable Integer getLayer() {
+  public @NullableDecl Integer getLayer() {
     return layer;
   }
 
@@ -219,7 +219,7 @@ public class WindowHierarchyElement {
    *     determined
    * @see android.view.accessibility.AccessibilityWindowInfo#getType()
    */
-  public @Nullable Integer getType() {
+  public @NullableDecl Integer getType() {
     return type;
   }
 
@@ -228,7 +228,7 @@ public class WindowHierarchyElement {
    *     if not, or {@code null} if this cannot be determined
    * @see android.view.accessibility.AccessibilityWindowInfo#isFocused()
    */
-  public @Nullable Boolean isFocused() {
+  public @NullableDecl Boolean isFocused() {
     return focused;
   }
 
@@ -237,7 +237,7 @@ public class WindowHierarchyElement {
    *     Boolean#FALSE} if not, or {@code null} if this cannot be determined
    * @see android.view.accessibility.AccessibilityWindowInfo#isAccessibilityFocused()
    */
-  public @Nullable Boolean isAccessibilityFocused() {
+  public @NullableDecl Boolean isAccessibilityFocused() {
     return accessibilityFocused;
   }
 
@@ -246,7 +246,7 @@ public class WindowHierarchyElement {
    *     not, or {@code null} if this cannot be determined
    * @see android.view.accessibility.AccessibilityWindowInfo#isActive()
    */
-  public @Nullable Boolean isActive() {
+  public @NullableDecl Boolean isActive() {
     return active;
   }
 
@@ -328,7 +328,7 @@ public class WindowHierarchyElement {
    * WindowHierarchyElement#builder}.
    */
   public static class Builder {
-    protected @Nullable WindowHierarchyElementProto proto;
+    protected @NullableDecl WindowHierarchyElementProto proto;
 
     Builder() {}
 

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/WindowHierarchyElementAndroid.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/WindowHierarchyElementAndroid.java
@@ -34,8 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Representation of a {@link Window} hierarchy for accessibility checking
@@ -53,19 +53,19 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
   private final List<ViewHierarchyElementAndroid> viewHierarchyElements;
 
   // This field is set to a non-null value after construction.
-  private @MonotonicNonNull AccessibilityHierarchyAndroid accessibilityHierarchy;
+  private @MonotonicNonNullDecl AccessibilityHierarchyAndroid accessibilityHierarchy;
 
   private WindowHierarchyElementAndroid(
       int id,
-      @Nullable Integer parentId,
+      @NullableDecl Integer parentId,
       List<Integer> childIds,
-      @Nullable Integer windowId,
-      @Nullable Integer layer,
-      @Nullable Integer type,
-      @Nullable Boolean focused,
-      @Nullable Boolean accessibilityFocused,
-      @Nullable Boolean active,
-      @Nullable Rect boundsInScreen,
+      @NullableDecl Integer windowId,
+      @NullableDecl Integer layer,
+      @NullableDecl Integer type,
+      @NullableDecl Boolean focused,
+      @NullableDecl Boolean accessibilityFocused,
+      @NullableDecl Boolean active,
+      @NullableDecl Rect boundsInScreen,
       List<ViewHierarchyElementAndroid> viewHierarchyElements) {
     super(
         id,
@@ -87,7 +87,7 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
    * @see AccessibilityWindowInfo#getRoot()
    */
   @Override
-  public @Nullable ViewHierarchyElementAndroid getRootView() {
+  public @NullableDecl ViewHierarchyElementAndroid getRootView() {
     if (viewHierarchyElements.isEmpty()) {
       return null;
     }
@@ -111,7 +111,7 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
    * @see AccessibilityWindowInfo#getParent()
    */
   @Override
-  public @Nullable WindowHierarchyElementAndroid getParentWindow() {
+  public @NullableDecl WindowHierarchyElementAndroid getParentWindow() {
     Integer parentIdTmp = parentId;
     return (parentIdTmp != null) ? getAccessibilityHierarchy().getWindowById(parentIdTmp) : null;
   }
@@ -149,8 +149,8 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
   @Override
   public AccessibilityHierarchyAndroid getAccessibilityHierarchy() {
 
-    // The type is explicit because the @MonotonicNonNull field is not read as @Nullable.
-    return Preconditions.<@Nullable AccessibilityHierarchyAndroid>checkNotNull(
+    // The type is explicit because the @MonotonicNonNull field is not read as @NullableDecl.
+    return Preconditions.<AccessibilityHierarchyAndroid>checkNotNull(
         accessibilityHierarchy);
   }
 
@@ -287,9 +287,9 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
   private static ViewHierarchyElementAndroid buildViewHierarchy(
       AccessibilityNodeInfo forInfo,
       List<ViewHierarchyElementAndroid> elementList,
-      @Nullable ViewHierarchyElementAndroid parent,
+      @NullableDecl ViewHierarchyElementAndroid parent,
       Map<ViewHierarchyElementAndroid, AccessibilityNodeInfo> elementToNodeInfoMap,
-      @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
+      @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
     checkNotNull(forInfo, "Attempted to build hierarchy from null root node");
 
     ViewHierarchyElementAndroid element =
@@ -329,7 +329,7 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
   private static ViewHierarchyElementAndroid buildViewHierarchy(
       View forView,
       List<ViewHierarchyElementAndroid> elementList,
-      @Nullable ViewHierarchyElementAndroid parent,
+      @NullableDecl ViewHierarchyElementAndroid parent,
       Map<ViewHierarchyElementAndroid, View> elementToViewMap) {
     ViewHierarchyElementAndroid element =
         ViewHierarchyElementAndroid.newBuilder(elementList.size(), parent, forView).build();
@@ -351,7 +351,7 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
   private static ViewHierarchyElementAndroid buildViewHierarchy(
       Parcel fromParcel,
       List<ViewHierarchyElementAndroid> elementList,
-      @Nullable ViewHierarchyElementAndroid parent) {
+      @NullableDecl ViewHierarchyElementAndroid parent) {
     ViewHierarchyElementAndroid element =
         ViewHierarchyElementAndroid.newBuilder(elementList.size(), parent, fromParcel).build();
     elementList.add(element);
@@ -378,7 +378,7 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
   static BuilderAndroid newBuilder(
       int id,
       AccessibilityWindowInfo window,
-      @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
+      @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
     BuilderAndroid builder = new BuilderAndroid(id);
     builder.fromWindowInfo = checkNotNull(window);
     builder.extraDataExtractor = extraDataExtractor;
@@ -392,7 +392,7 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
   static BuilderAndroid newBuilder(
       int id,
       AccessibilityNodeInfo nodeInfo,
-      @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
+      @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
     BuilderAndroid builder = new BuilderAndroid(id);
     builder.fromNodeInfo = checkNotNull(nodeInfo);
     builder.extraDataExtractor = extraDataExtractor;
@@ -420,24 +420,24 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
    */
   public static class BuilderAndroid extends Builder {
     private final int id;
-    private @Nullable View fromRootView;
-    private @Nullable AccessibilityWindowInfo fromWindowInfo;
-    private @Nullable AccessibilityNodeInfo fromNodeInfo;
-    private @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor;
-    private @Nullable Parcel in;
-    private @Nullable WindowHierarchyElementAndroid parent;
-    private @MonotonicNonNull Map<Long, AccessibilityNodeInfo> nodeInfoOriginMap;
-    private @MonotonicNonNull Map<Long, View> viewOriginMap;
+    private @NullableDecl View fromRootView;
+    private @NullableDecl AccessibilityWindowInfo fromWindowInfo;
+    private @NullableDecl AccessibilityNodeInfo fromNodeInfo;
+    private @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor;
+    private @NullableDecl Parcel in;
+    private @NullableDecl WindowHierarchyElementAndroid parent;
+    private @MonotonicNonNullDecl Map<Long, AccessibilityNodeInfo> nodeInfoOriginMap;
+    private @MonotonicNonNullDecl Map<Long, View> viewOriginMap;
 
-    private @Nullable Integer parentId;
+    private @NullableDecl Integer parentId;
     private final List<Integer> childIds = new ArrayList<>();
-    private @Nullable Integer windowId;
-    private @Nullable Integer layer;
-    private @Nullable Integer type;
-    private @Nullable Boolean focused;
-    private @Nullable Boolean accessibilityFocused;
-    private @Nullable Boolean active;
-    private @Nullable Rect boundsInScreen;
+    private @NullableDecl Integer windowId;
+    private @NullableDecl Integer layer;
+    private @NullableDecl Integer type;
+    private @NullableDecl Boolean focused;
+    private @NullableDecl Boolean accessibilityFocused;
+    private @NullableDecl Boolean active;
+    private @NullableDecl Rect boundsInScreen;
     private List<ViewHierarchyElementAndroid> viewHierarchyElements;
 
     BuilderAndroid(int id) {
@@ -445,7 +445,7 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
       this.id = id;
     }
 
-    public BuilderAndroid setParent(@Nullable WindowHierarchyElementAndroid parent) {
+    public BuilderAndroid setParent(@NullableDecl WindowHierarchyElementAndroid parent) {
       this.parent = parent;
       return this;
     }
@@ -492,10 +492,10 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
 
     private WindowHierarchyElementAndroid construct(
         int id,
-        @Nullable WindowHierarchyElementAndroid parent,
+        @NullableDecl WindowHierarchyElementAndroid parent,
         AccessibilityWindowInfo fromWindow,
         Map<ViewHierarchyElementAndroid, AccessibilityNodeInfo> elementToNodeInfoMap,
-        @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
+        @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
       // Bookkeeping
       this.parentId = (parent != null) ? parent.getId() : null;
 
@@ -544,10 +544,10 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
 
     private WindowHierarchyElementAndroid construct(
         int id,
-        @Nullable WindowHierarchyElementAndroid parent,
+        @NullableDecl WindowHierarchyElementAndroid parent,
         AccessibilityNodeInfo fromRootNode,
         Map<ViewHierarchyElementAndroid, AccessibilityNodeInfo> elementToNodeInfoMap,
-        @Nullable AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
+        @NullableDecl AccessibilityNodeInfoExtraDataExtractor extraDataExtractor) {
       // Bookkeeping
       this.parentId = (parent != null) ? parent.getId() : null;
 
@@ -591,7 +591,7 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
 
     private WindowHierarchyElementAndroid construct(
         int id,
-        @Nullable WindowHierarchyElementAndroid parent,
+        @NullableDecl WindowHierarchyElementAndroid parent,
         View fromRootView,
         Map<ViewHierarchyElementAndroid, View> elementToViewMap) {
       // Bookkeeping
@@ -631,7 +631,7 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
     }
 
     private WindowHierarchyElementAndroid construct(
-        int id, @Nullable WindowHierarchyElementAndroid parent, Parcel in) {
+        int id, @NullableDecl WindowHierarchyElementAndroid parent, Parcel in) {
       // Bookkeeping
       this.parentId = (parent != null) ? parent.getId() : null;
 
@@ -716,8 +716,8 @@ public class WindowHierarchyElementAndroid extends WindowHierarchyElement {
     }
 
     private void populateOriginMaps(
-        @Nullable Map<ViewHierarchyElementAndroid, View> elementToViewMap,
-        @Nullable Map<ViewHierarchyElementAndroid, AccessibilityNodeInfo> elementToNodeInfoMap) {
+        @NullableDecl Map<ViewHierarchyElementAndroid, View> elementToViewMap,
+        @NullableDecl Map<ViewHierarchyElementAndroid, AccessibilityNodeInfo> elementToNodeInfoMap) {
       if (viewOriginMap != null) {
         for (Map.Entry<ViewHierarchyElementAndroid, View> entry :
             checkNotNull(elementToViewMap).entrySet()) {

--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/utils/contrast/ContrastSwatch.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/utils/contrast/ContrastSwatch.java
@@ -24,11 +24,12 @@ import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Represents a section of a screenshot bitmap and its associated color and contrast data. */
 public class ContrastSwatch {
@@ -109,7 +110,13 @@ public class ContrastSwatch {
     // Sort colors with a max heap.
     final PriorityQueue<Map.Entry<Integer, Integer>> frequencyMaxHeap =
         new PriorityQueue<>(
-            dominantColorHistogram.getColors().size(), (a, b) -> (b.getValue() - a.getValue()));
+            dominantColorHistogram.getColors().size(),
+            new Comparator<Map.Entry<Integer, Integer>>() {
+              @Override
+              public int compare(Map.Entry<Integer, Integer> a, Map.Entry<Integer, Integer> b) {
+                return (b.getValue() - a.getValue());
+              }
+            });
     for (Map.Entry<Integer, Integer> entry : dominantColorHistogram.entrySet()) {
       frequencyMaxHeap.offer(entry);
     }
@@ -183,7 +190,12 @@ public class ContrastSwatch {
         dominantColorsList.add(entry);
       }
     }
-    Collections.sort(dominantColorsList, (a, b) -> (b.getValue() - a.getValue()));
+    Collections.sort(dominantColorsList, new Comparator<Map.Entry<Integer, Integer>>() {
+      @Override
+      public int compare(Map.Entry<Integer, Integer> a, Map.Entry<Integer, Integer> b) {
+        return (b.getValue() - a.getValue());
+      }
+    });
 
     // Combine similar colors
     for (Map.Entry<Integer, Integer> entry : dominantColorsList) {
@@ -347,7 +359,7 @@ public class ContrastSwatch {
       return colorHistogram.entrySet();
     }
 
-    @Nullable
+    @NullableDecl
     Integer getCount(int color) {
       return colorHistogram.get(color);
     }

--- a/src/main/java/com/google/android/libraries/accessibility/utils/log/LogUtils.java
+++ b/src/main/java/com/google/android/libraries/accessibility/utils/log/LogUtils.java
@@ -19,7 +19,7 @@ package com.google.android.libraries.accessibility.utils.log;
 import android.util.Log;
 import com.google.common.base.Strings;
 import java.util.IllegalFormatException;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Handles logging formatted strings. */
 public class LogUtils {
@@ -29,12 +29,12 @@ public class LogUtils {
   /** Plug-in for custom printing complex objects, especially accessibility event & node. */
   public interface ParameterCustomizer {
     /** Converts an object for display. */
-    @Nullable
-    Object customize(@Nullable Object object);
+    @NullableDecl
+    Object customize(@NullableDecl Object object);
   }
 
   /** Customizer for log parameters. By default, changes nothing. */
-  private static @Nullable ParameterCustomizer parameterCustomizer = null;
+  private static @NullableDecl ParameterCustomizer parameterCustomizer = null;
 
   private static final String TAG = "LogUtils";
 
@@ -65,7 +65,7 @@ public class LogUtils {
    * @param args String formatter arguments
    */
   public static void logWithLimit(
-      String tag, int priority, int index, int limit, String format, @Nullable Object... args) {
+      String tag, int priority, int index, int limit, String format, @NullableDecl Object... args) {
     String formatWithIndex;
     if (index > limit) {
       return;
@@ -85,7 +85,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void v(String tag, @Nullable String format, @Nullable Object... args) {
+  public static void v(String tag, @NullableDecl String format, @NullableDecl Object... args) {
     log(tag, Log.VERBOSE, format, args);
   }
 
@@ -97,7 +97,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void v(String tag, Throwable throwable, String format, @Nullable Object... args) {
+  public static void v(String tag, Throwable throwable, String format, @NullableDecl Object... args) {
     log(tag, Log.VERBOSE, throwable, format, args);
   }
 
@@ -108,7 +108,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void d(String tag, String format, @Nullable Object... args) {
+  public static void d(String tag, String format, @NullableDecl Object... args) {
     log(tag, Log.DEBUG, format, args);
   }
 
@@ -120,7 +120,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void d(String tag, Throwable throwable, String format, @Nullable Object... args) {
+  public static void d(String tag, Throwable throwable, String format, @NullableDecl Object... args) {
     log(tag, Log.DEBUG, throwable, format, args);
   }
 
@@ -131,7 +131,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void i(String tag, String format, @Nullable Object... args) {
+  public static void i(String tag, String format, @NullableDecl Object... args) {
     log(tag, Log.INFO, format, args);
   }
 
@@ -143,7 +143,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void i(String tag, Throwable throwable, String format, @Nullable Object... args) {
+  public static void i(String tag, Throwable throwable, String format, @NullableDecl Object... args) {
     log(tag, Log.INFO, throwable, format, args);
   }
 
@@ -154,7 +154,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void w(String tag, String format, @Nullable Object... args) {
+  public static void w(String tag, String format, @NullableDecl Object... args) {
     log(tag, Log.WARN, format, args);
   }
 
@@ -166,7 +166,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void w(String tag, Throwable throwable, String format, @Nullable Object... args) {
+  public static void w(String tag, Throwable throwable, String format, @NullableDecl Object... args) {
     log(tag, Log.WARN, throwable, format, args);
   }
 
@@ -177,7 +177,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void e(String tag, @Nullable String format, @Nullable Object... args) {
+  public static void e(String tag, @NullableDecl String format, @NullableDecl Object... args) {
     log(tag, Log.ERROR, format, args);
   }
 
@@ -189,7 +189,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void e(String tag, Throwable throwable, String format, @Nullable Object... args) {
+  public static void e(String tag, Throwable throwable, String format, @NullableDecl Object... args) {
     log(tag, Log.ERROR, throwable, format, args);
   }
 
@@ -200,7 +200,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void wtf(String tag, String format, @Nullable Object... args) {
+  public static void wtf(String tag, String format, @NullableDecl Object... args) {
     log(tag, Log.ASSERT, format, args);
   }
 
@@ -212,7 +212,7 @@ public class LogUtils {
    * @param format A format string, see {@link String#format(String, Object...)}
    * @param args String formatter arguments
    */
-  public static void wtf(String tag, Throwable throwable, String format, @Nullable Object... args) {
+  public static void wtf(String tag, Throwable throwable, String format, @NullableDecl Object... args) {
     log(tag, Log.ASSERT, throwable, format, args);
   }
 
@@ -233,9 +233,9 @@ public class LogUtils {
   public static void log(
       String tag,
       int priority,
-      @Nullable Throwable throwable,
-      @Nullable String format,
-      @Nullable Object... args) {
+      @NullableDecl Throwable throwable,
+      @NullableDecl String format,
+      @NullableDecl Object... args) {
     if (priority < sLogLevel) {
       return;
     }
@@ -278,12 +278,12 @@ public class LogUtils {
    * @param args String formatter arguments
    */
   public static void log(
-      String tag, int priority, @Nullable String format, @Nullable Object... args) {
+      String tag, int priority, @NullableDecl String format, @NullableDecl Object... args) {
     log(tag, priority, null, format, args);
   }
 
   /** Sets customizer for log parameters. */
-  public static void setParameterCustomizer(@Nullable ParameterCustomizer parameterCustomizerArg) {
+  public static void setParameterCustomizer(@NullableDecl ParameterCustomizer parameterCustomizerArg) {
     parameterCustomizer = parameterCustomizerArg;
   }
 


### PR DESCRIPTION
Dependent projects (like androidx.test.espresso.accessibility) still
need to use java7 source compatibility. So convert to java7 by
- replacing lambdas with inner classes
- use org.checkerframework compat.qual instead of qual