### PR TITLE
Downgrade to checker-qual:2.5.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,10 @@ dependencies {
     implementation 'androidx.core:core:1.0.0'
     implementation 'com.google.android.material:material:1.2.0-rc01'
     implementation 'com.google.guava:guava:28.2-android'
-    implementation 'org.checkerframework:checker:3.1.1'
+    // use same version of checker framework used in guava android,
+    // to avoid duplicate class and dexing errors
+    // see https://github.com/android/android-test/issues/861
+    implementation 'org.checkerframework:checker-qual:2.5.5'
     implementation 'org.hamcrest:hamcrest-library:2.2'
     implementation 'org.hamcrest:hamcrest-core:2.2'
     implementation 'org.jsoup:jsoup:1.12.2'


### PR DESCRIPTION
Using checker:3.1.1 can lead to duplicate class errors,
since it embeds checker-qual inside it.

Since this project doesn't appear to need the full checkerframework,
downgrade to just use checker-qual, at the same version as guava.

See https://github.com/android/android-test/issues/861