### PR TITLE
Downgrade ATF's hamcrest dependency from 2.2 to 1.3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,8 +126,8 @@ dependencies {
     // to avoid duplicate class and dexing errors
     // see https://github.com/android/android-test/issues/861
     implementation 'org.checkerframework:checker-qual:3.22.1'
-    implementation 'org.hamcrest:hamcrest-core:2.2'
-    implementation 'org.hamcrest:hamcrest-library:2.2'
+    implementation 'org.hamcrest:hamcrest-core:1.3'
+    implementation 'org.hamcrest:hamcrest-library:1.3'
     implementation 'org.jsoup:jsoup:1.15.1'
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.2'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.2'


### PR DESCRIPTION
This aligns ATF with its other dependencies like JUnit and espresso core which depend on hamcrest 1.3. Hamcrest 2.2 is not binary compatible with 1.3, so ATF's declaration of 2.2 here can cause conflicts.
See https://github.com/android/android-test/issues/1352