### PR TITLE
Make AccessibilityViewCheckException an EspressoException

### DIFF
--- a/src/main/java/com/google/android/apps/common/testing/accessibility/framework/integrations/espresso/AccessibilityViewCheckException.java
+++ b/src/main/java/com/google/android/apps/common/testing/accessibility/framework/integrations/espresso/AccessibilityViewCheckException.java
@@ -17,6 +17,8 @@ package com.google.android.apps.common.testing.accessibility.framework.integrati
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import androidx.test.espresso.EspressoException;
+
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultDescriptor;
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityViewCheckResult;
 import java.util.List;
@@ -25,7 +27,8 @@ import java.util.Locale;
 /** An exception class to be used for throwing exceptions with accessibility results. */
 public final class AccessibilityViewCheckException
     extends com.google.android.apps.common.testing.accessibility.framework.integrations
-        .AccessibilityViewCheckException {
+        .AccessibilityViewCheckException
+    implements EspressoException {
 
   private final AccessibilityCheckResultDescriptor resultDescriptor;
 


### PR DESCRIPTION
Let's improve debuggability with this minor change.

Espresso's default failure handler [catches](https://github.com/android/android-test/blob/10dfce51b4092b91601791adca76f23d3d470e33/espresso/core/java/androidx/test/espresso/base/DefaultFailureHandler.java#L83) EspressoException and changes its [stacktrace](https://github.com/android/android-test/blob/10dfce51b4092b91601791adca76f23d3d470e33/espresso/core/java/androidx/test/espresso/base/EspressoExceptionHandler.java#L34) to the test runner's thread. As a result:

| Stacktrace before | Stacktrace after |
| ------------------ | ---------------- | 
| <img width="480" alt="Stacktrace that does not include any test code or production code" src="https://github.com/google/Accessibility-Test-Framework-for-Android/assets/45464063/61d7ec72-4989-4d66-a5c6-c1fb6f202c94"> | <img width="480" alt="Stacktrace that does include the test code that triggered the AccessibilityCheckException" src="https://github.com/google/Accessibility-Test-Framework-for-Android/assets/45464063/03447d6a-caf0-40cf-9aea-f71210df0178"> |