### PR TITLE
Upgrade guava, protobuf, jsoup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ apply plugin: 'com.google.protobuf'
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.19.1'
+        artifact = 'com.google.protobuf:protoc:3.25.5'
     }
     generateProtoTasks {
         all().each { task ->
@@ -79,7 +79,7 @@ publishing {
         mavenAar(MavenPublication) {
             groupId 'com.google.android.apps.common.testing.accessibility.framework'
             artifactId 'accessibility-test-framework'
-            version '4.1.1'
+            version '4.1.2'
             from components.android
             artifact sourceJar
             artifact javadocJar
@@ -120,15 +120,15 @@ dependencies {
     implementation 'androidx.test:rules:1.4.0'
     implementation 'com.google.android.material:material:1.2.0-rc01'
     implementation 'com.google.errorprone:error_prone_annotations:2.14.0'
-    implementation 'com.google.guava:guava:31.0.1-android'
-    implementation 'com.google.protobuf:protobuf-javalite:3.19.1'
+    implementation 'com.google.guava:guava:32.0.0-android'
+    implementation 'com.google.protobuf:protobuf-javalite:3.25.5'
     // use same version of checker framework used in guava android,
     // to avoid duplicate class and dexing errors
     // see https://github.com/android/android-test/issues/861
     implementation 'org.checkerframework:checker-qual:3.22.1'
     implementation 'org.hamcrest:hamcrest-core:1.3'
     implementation 'org.hamcrest:hamcrest-library:1.3'
-    implementation 'org.jsoup:jsoup:1.15.1'
+    implementation 'org.jsoup:jsoup:1.15.3'
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.2'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.2'
 }


### PR DESCRIPTION
This pulls in fixes for the following security vulnerabilities
- CVE-2022-3510
- CVE-2022-3171
- CVE-2023-2976
- CVE-2022-36033
- CVE-2024-7254